### PR TITLE
Allow video embeds in Markdown

### DIFF
--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -198,7 +198,7 @@ export default {
                     'data: papermc.io paper.readthedocs.io',
                     'https:', // ppl can use images in descriptions, we would need an image proxy or smth
                 ],
-                frameSrc: ["'self'", 'http://localhost/', 'https://papermc.io/', 'https://hangar.crowdin.com'],
+                frameSrc: ["'self'", 'http://localhost/', 'https://papermc.io/', 'https://hangar.crowdin.com', 'https://www.youtube-nocookie.com'],
                 manifestSrc: ["'self'"],
                 connectSrc: ["'self'", 'https://www.google-analytics.com', 'https://stats.g.doubleclick.net', 'https://hangar.crowdin.com'],
                 mediaSrc: ["'self'"],

--- a/src/main/java/io/papermc/hangar/service/internal/MarkdownService.java
+++ b/src/main/java/io/papermc/hangar/service/internal/MarkdownService.java
@@ -13,6 +13,7 @@ import com.vladsch.flexmark.ext.gitlab.GitLabExtension;
 import com.vladsch.flexmark.ext.tables.TablesExtension;
 import com.vladsch.flexmark.ext.typographic.TypographicExtension;
 import com.vladsch.flexmark.ext.wikilink.WikiLinkExtension;
+import com.vladsch.flexmark.ext.youtube.embedded.YouTubeLinkExtension;
 import com.vladsch.flexmark.html.HtmlRenderer;
 import com.vladsch.flexmark.html.LinkResolver;
 import com.vladsch.flexmark.html.LinkResolverFactory;
@@ -68,7 +69,8 @@ public class MarkdownService {
                                 EmojiExtension.create(),
                                 FootnoteExtension.create(),
                                 AdmonitionExtension.create(),
-                                GitLabExtension.create()
+                                GitLabExtension.create(),
+                                YouTubeLinkExtension.create()
                         )
                 );
 

--- a/src/main/java/io/papermc/hangar/util/BBCodeConverter.java
+++ b/src/main/java/io/papermc/hangar/util/BBCodeConverter.java
@@ -37,6 +37,7 @@ public class BBCodeConverter {
         REPLACERS.put("i", (tag, tagArg, content) -> "*" + content + "*");
         REPLACERS.put("s", (tag, tagArg, content) -> "~~" + content + "~~");
         REPLACERS.put("img", (tag, tagArg, content) -> "![" + content + "](" + content + ")");
+        REPLACERS.put("media", (tag, tagArg, content) -> "youtube".equals(tagArg) ? "@[YouTube](https://youtu.be/" + content + ")" : null);
         REPLACERS.put("url", (tag, tagArg, content) -> {
             String url = tagArg == null ? content : tagArg;
             char firstCharacter = url.length() > 2 ? url.charAt(0) : '-';
@@ -106,7 +107,11 @@ public class BBCodeConverter {
             }
 
             String processed = replacer.process(currentTag, currentArg, currentContent);
-            s = s.substring(0, index) + processed + s.substring(closingIndex);
+            if (processed == null) {
+                index++;
+            } else {
+                s = s.substring(0, index) + processed + s.substring(closingIndex);
+            }
         }
         return s;
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -147,6 +147,7 @@ hangar:
       timeout: 10000
     safe-download-hosts:
       - "github.com"
+      - "youtu.be"
 
   discourse:
     enabled: true

--- a/src/test/java/io/papermc/hangar/util/BBCodeConverterTest.java
+++ b/src/test/java/io/papermc/hangar/util/BBCodeConverterTest.java
@@ -61,6 +61,18 @@ class BBCodeConverterTest {
     }
 
     @Test
+    void testMedia() {
+        String result = converter.convertToMarkdown("[MEDIA=youtube]dQw4w9WgXcQ[/MEDIA]");
+        Assertions.assertEquals("@[YouTube](https://youtu.be/dQw4w9WgXcQ)", result);
+    }
+
+    @Test
+    void testMediaUnsupportedPlatform() {
+        String result = converter.convertToMarkdown("[MEDIA=vimeo]163721649[/MEDIA]");
+        Assertions.assertEquals("[MEDIA=vimeo]163721649[/MEDIA]", result);
+    }
+
+    @Test
     void testComplexExample() throws IOException {
         // Be sure to retest/-generate this output if "breaking" changes are made, for example to spacing
         String input = Files.readString(PATH.resolve("BBCodeExample.txt"));


### PR DESCRIPTION
Hello,

This PR adds the `YouTubeLinkExtension` in the `MarkdownService` as suggested in #291 and a conversion from BBCode to Markdown for this format. The CSP policy has also been updated to support the embeds.