### PR TITLE
Improve Create new button text

### DIFF
--- a/frontend/components/layouts/Header.vue
+++ b/frontend/components/layouts/Header.vue
@@ -19,7 +19,7 @@
             <template #activator="{ on, attrs }">
                 <v-btn v-bind="attrs" color="primary" class="mr-1" v-on="on">
                     {{ $t('nav.createNew') }}
-                    <v-icon right> mdi-chevron-down </v-icon>
+                    <v-icon right> mdi-plus-box-multiple </v-icon>
                 </v-btn>
             </template>
             <Dropdown :controls="newControls" />

--- a/frontend/components/layouts/Header.vue
+++ b/frontend/components/layouts/Header.vue
@@ -19,7 +19,7 @@
             <template #activator="{ on, attrs }">
                 <v-btn v-bind="attrs" color="primary" class="mr-1" v-on="on">
                     {{ $t('nav.createNew') }}
-                    <v-icon right> mdi-plus-box-multiple </v-icon>
+                    <v-icon right> mdi-chevron-down </v-icon>
                 </v-btn>
             </template>
             <Dropdown :controls="newControls" />

--- a/frontend/locales/en.ts
+++ b/frontend/locales/en.ts
@@ -72,7 +72,7 @@ export default {
         fakeUserEnabled: 'Fake user is enabled. {0} is therefore disabled'
       }
     },
-    createNew: 'Create new...',
+    createNew: 'Create',
     new: {
       project: 'New Project',
       organization: 'New Organization'

--- a/frontend/locales/en.ts
+++ b/frontend/locales/en.ts
@@ -72,7 +72,7 @@ export default {
         fakeUserEnabled: 'Fake user is enabled. {0} is therefore disabled'
       }
     },
-    createNew: 'Create',
+    createNew: 'New',
     new: {
       project: 'New Project',
       organization: 'New Organization'


### PR DESCRIPTION
I changed the Create New button text from "Create New..." to "Create". Having it as "Create New..." was confusing. It gave me the impression, that the text on the button was just cut-off due to misconfigured layout. I think this should improve the User Experience, while adding more space to the header.

Before PR:
![image](https://user-images.githubusercontent.com/70709113/149778608-d68c351d-948b-4ad2-a74b-5b56cf48a068.png)
After PR:
![image](https://user-images.githubusercontent.com/70709113/149778641-fd28a22b-651c-46f3-8db5-cdeb94c0f00c.png)
