### PR TITLE
Link to new docs and grab logo from there aswell

### DIFF
--- a/frontend-new/src/components/layout/Header.vue
+++ b/frontend-new/src/components/layout/Header.vue
@@ -41,7 +41,7 @@ const navBarMenuLinksMoreFromPaper = [
   { link: "https://papermc.io/", label: t("nav.hangar.home"), icon: IconMdiHome },
   { link: "https://forums.papermc.io/", label: t("nav.hangar.forums"), icon: IconMdiForum },
   { link: "https://github.com/PaperMC", label: t("nav.hangar.code"), icon: IconMdiCodeBraces },
-  { link: "https://paper.readthedocs.io/en/latest/", label: t("nav.hangar.docs"), icon: IconMdiBookOpen },
+  { link: "https://docs.papermc.io/", label: t("nav.hangar.docs"), icon: IconMdiBookOpen },
   { link: "https://papermc.io/javadocs", label: t("nav.hangar.javadocs"), icon: IconMdiLanguageJava },
   { link: "/", label: t("nav.hangar.hangar"), icon: IconMdiPuzzle },
   { link: "https://papermc.io/downloads", label: t("nav.hangar.downloads"), icon: IconMdiDownloadCircle },

--- a/frontend-new/src/composables/useSeo.ts
+++ b/frontend-new/src/composables/useSeo.ts
@@ -10,7 +10,7 @@ export function useSeo(
 ): HeadObject {
   description = description || "Plugin repository for Paper plugins and more!";
   const canonical = baseUrl() + (route.fullPath.endsWith("/") ? route.fullPath : `${route.fullPath}/`);
-  image = image || "https://paper.readthedocs.io/en/latest/_images/papermc_logomark_500.png";
+  image = image || "https://docs.papermc.io/img/paper.png";
   image = image.startsWith("http") ? image : baseUrl() + image;
   const seo = {
     title,

--- a/frontend/components/layouts/Header.vue
+++ b/frontend/components/layouts/Header.vue
@@ -99,7 +99,7 @@
                             <img
                                 :src="$util.avatarUrl(currentUser.name)"
                                 :alt="currentUser.name"
-                                @error="$event.target.src = 'https://paper.readthedocs.io/en/latest/_images/papermc_logomark_500.png'"
+                                @error="$event.target.src = 'https://docs.papermc.io/img/paper.png'"
                             />
                         </v-avatar>
                     </v-badge>
@@ -178,7 +178,7 @@ export default class Header extends HangarComponent {
             title: this.$t('nav.hangar.code'),
         });
         controls.push({
-            link: 'https://paper.readthedocs.io',
+            link: 'https://docs.papermc.io/',
             icon: 'mdi-book',
             title: this.$t('nav.hangar.docs'),
         });

--- a/frontend/components/users/UserAvatar.vue
+++ b/frontend/components/users/UserAvatar.vue
@@ -32,7 +32,7 @@ export default class UserAvatar extends Vue {
 
     get src(): string {
         if (this.errored) {
-            return 'https://paper.readthedocs.io/en/latest/_images/papermc_logomark_500.png';
+            return 'https://docs.papermc.io/img/paper.png';
         } else if (this.imgSrc) {
             return this.imgSrc;
         } else if (this.avatarUrl) {

--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -213,7 +213,7 @@ export default {
                     'https://www.google-analytics.com',
                     'https://www.gravatar.com',
                     authHost,
-                    'data: papermc.io paper.readthedocs.io',
+                    'data: papermc.io docs.papermc.io',
                     'https:', // ppl can use images in descriptions, we would need an image proxy or smth
                 ],
                 frameSrc: ["'self'", 'http://localhost/', 'https://papermc.io/', 'https://hangar.crowdin.com', 'https://www.youtube-nocookie.com'],

--- a/frontend/plugins/seo.ts
+++ b/frontend/plugins/seo.ts
@@ -9,7 +9,7 @@ const createUtil = (context: Context) => {
         head(title: string | TranslateResult, description: string | TranslateResult | null, route: Route, image: string | null): MetaInfo {
             description = description || 'Plugin repository for Paper plugins and more!';
             const canonical = this.baseUrl() + (route.fullPath.endsWith('/') ? route.fullPath : route.fullPath + '/');
-            image = image || 'https://paper.readthedocs.io/en/latest/_images/papermc_logomark_500.png';
+            image = image || 'https://docs.papermc.io/img/paper.png';
             image = image.startsWith('http') ? image : this.baseUrl() + image;
             const seo = {
                 title,

--- a/src/main/java/io/papermc/hangar/config/hangar/HangarConfig.java
+++ b/src/main/java/io/papermc/hangar/config/hangar/HangarConfig.java
@@ -18,7 +18,7 @@ import java.util.List;
 @ComponentScan("io.papermc.hangar")
 public class HangarConfig {
 
-    private String logo = "https://paper.readthedocs.io/en/latest/_images/papermc_logomark_500.png";
+    private String logo = "https://docs.papermc.io/img/paper.png";
     private String service = "Hangar";
     private List<Sponsor> sponsors;
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -150,7 +150,7 @@ hangar:
     api:
       url: "http://localhost:8000"
       # avatar-url: "http://localhost:8000/avatar/%s?size=120x120" # only comment in if you run auth locally
-      avatar-url: "https://paper.readthedocs.io/en/latest/_images/papermc_logomark_500.png"
+      avatar-url: "https://docs.papermc.io/img/paper.png"
       timeout: 10000
     safe-download-hosts:
       - "github.com"


### PR DESCRIPTION
Changes the docs link in the header to the new docs site and grabs the logo from there aswell. Fetching the logo from the docs site still isn't an ideal solution, but hey, at least it loads the icon now :P