### PR TITLE
Container style adjustements

### DIFF
--- a/frontend-new/src/components/design/Container.vue
+++ b/frontend-new/src/components/design/Container.vue
@@ -5,7 +5,7 @@ const props = defineProps<{
 </script>
 
 <template>
-  <div :class="'max-w-1200px m-auto p-4 ' + (props.class || '')">
+  <div :class="'max-w-screen-xl mx-auto p-4 ' + (props.class || '')">
     <slot></slot>
   </div>
 </template>

--- a/frontend-new/src/components/layout/Header.vue
+++ b/frontend-new/src/components/layout/Header.vue
@@ -68,7 +68,7 @@ authLog("render with user " + authStore.user?.name);
       <Announcement v-for="(announcement, idx) in backendData.announcements" :key="idx" :announcement="announcement" />
     </div>
 
-    <nav class="container mx-auto flex justify-between px-4 py-2">
+    <nav class="max-w-screen-xl mx-auto flex justify-between px-4 py-2">
       <!-- Left side items -->
       <div class="flex items-center gap-4">
         <Popover class="relative">


### PR DESCRIPTION
This PR adjusts the following styles:

**Container:**
- Use `max-w-screen-xl` instead of `max-w-1200px` for max width
- Use `mx-auto` instead of `m-auto`. Container are only centered horizontally, no need for the vertical margin

**Navbar "container":**
- Navbar now shrinks/grows the same way that normal containers do for better consistency across the site.