### PR TITLE
Clean up Front Page styling

### DIFF
--- a/frontend-new/src/pages/index.vue
+++ b/frontend-new/src/pages/index.vue
@@ -103,62 +103,59 @@ useHead(meta);
 </script>
 
 <template>
-  <div class="flex flex-col items-center pt-10">
-    <Alert v-if="loggedOut" class="mb-4 -mt-4" type="success">You have been logged out!</Alert>
-    <h2 class="text-3xl font-bold uppercase text-center">{{ i18n.t("hangar.projectSearch.title") }}</h2>
-    <!-- Search Bar & Sorting button -->
-    <div class="flex flex-row mt-6 rounded-md big-box-shadow">
-      <!-- Search Bar -->
+  <Container class="flex flex-col items-center gap-4">
+    <Alert v-if="loggedOut" type="success">You have been logged out!</Alert>
+    <h2 class="text-3xl font-bold uppercase text-center my-4">{{ i18n.t("hangar.projectSearch.title") }}</h2>
+    <!-- Search Bar -->
+    <div class="relative rounded-md flex shadow-lg w-full max-w-screen-md">
+      <!-- Text Input -->
       <input
         v-model="query"
-        class="rounded-l-md p-3 md:w-[80vw] max-w-800px focus-visible:(border-white) text-black"
+        class="rounded-l-md p-4 basis-full"
         type="text"
         :placeholder="i18n.t('hangar.projectSearch.query', [projects?.pagination.count])"
       />
       <!-- Sorting Button -->
-      <div class="rounded-r-md w-100px bg-gradient-to-r from-[#004ee9] to-[#367aff]">
-        <Menu>
-          <MenuButton class="rounded-r-md h-1/1 text-left font-semibold flex flex-row items-center gap-2 text-white p-2">
-            <span>{{ i18n.t("hangar.projectSearch.sortBy") }}</span>
-            <icon-mdi-sort-variant class="text-[1.2em] pointer-events-none overflow-hidden" />
-          </MenuButton>
-          <transition
-            enter-active-class="transition duration-100 ease-out"
-            enter-from-class="transform scale-95 opacity-0"
-            enter-to-class="transform scale-100 opacity-100"
-            leave-active-class="transition duration-75 ease-out"
-            leave-from-class="transform scale-100 opacity-100"
-            leave-to-class="transform scale-95 opacity-0"
-          >
-            <MenuItems class="absolute flex flex-col z-10 background-header drop-shadow-md rounded-md border-top-primary">
-              <MenuItem v-for="sorter in sorters" :key="sorter.id" v-slot="{ active }">
-                <button :class="{ 'bg-gradient-to-r from-[#004ee9] to-[#367aff] text-white': active }" class="p-2 text-left">
-                  {{ sorter.label }}
-                </button>
-              </MenuItem>
-            </MenuItems>
-          </transition>
-        </Menu>
-      </div>
+      <Menu>
+        <MenuButton class="bg-gradient-to-r from-[#004ee9] to-[#367aff] rounded-r-md text-left font-semibold flex items-center gap-2 text-white p-2">
+          <span class="whitespace-nowrap">{{ i18n.t("hangar.projectSearch.sortBy") }}</span>
+          <icon-mdi-sort-variant class="text-2xl pointer-events-none" />
+        </MenuButton>
+        <transition
+          enter-active-class="transition duration-100 ease-out"
+          enter-from-class="transform scale-95 opacity-0"
+          enter-to-class="transform scale-100 opacity-100"
+          leave-active-class="transition duration-75 ease-out"
+          leave-from-class="transform scale-100 opacity-100"
+          leave-to-class="transform scale-95 opacity-0"
+        >
+          <MenuItems class="absolute right-0 top-16 flex flex-col z-10 background-header drop-shadow-md rounded-md border-top-primary">
+            <MenuItem v-for="sorter in sorters" :key="sorter.id" v-slot="{ active }">
+              <button :class="{ 'bg-gradient-to-r from-[#004ee9] to-[#367aff] text-white': active }" class="p-2 text-left">
+                {{ sorter.label }}
+              </button>
+            </MenuItem>
+          </MenuItems>
+        </transition>
+      </Menu>
     </div>
-  </div>
-  <Container class="mt-5 flex flex-col justify-around gap-y-6" lg="flex-row gap-x-6 gap-y-0 ">
+  </Container>
+  <Container class="mt-5" lg="flex gap-6">
     <!-- Projects -->
-    <div class="min-h-800px" lg="w-2/3 min-w-2/3 max-w-2/3">
+    <div class="w-full mb-5" lg="mb-0">
       <ProjectList :projects="projects" />
     </div>
     <!-- Sidebar -->
-    <Card accent class="min-w-300px min-h-800px flex flex-col gap-4">
+    <Card accent class="min-w-300px flex flex-col gap-4">
       <div class="versions">
-        <h3 class="font-bold">Minecraft versions</h3>
-        <div class="flex flex-col gap-2 max-h-30 overflow-auto">
+        <h3 class="font-bold mb-1">Minecraft versions</h3>
+        <div class="flex flex-col gap-1 max-h-30 overflow-auto">
           <InputCheckbox v-for="version in versions" :key="version.version" v-model="filters.versions" :value="version.version" :label="version.version" />
         </div>
       </div>
-      <hr />
       <div class="categories">
-        <h3 class="font-bold">Categories</h3>
-        <div class="flex flex-col gap-2">
+        <h3 class="font-bold mb-1">Categories</h3>
+        <div class="flex flex-col gap-1">
           <InputCheckbox
             v-for="category in backendData.visibleCategories"
             :key="category.apiName"
@@ -168,10 +165,9 @@ useHead(meta);
           />
         </div>
       </div>
-      <hr />
       <div class="platforms">
-        <h3 class="font-bold">Platforms</h3>
-        <div class="flex flex-col gap-2">
+        <h3 class="font-bold mb-1">Platforms</h3>
+        <div class="flex flex-col gap-1">
           <InputCheckbox
             v-for="platform in backendData.visiblePlatforms"
             :key="platform.enumName"
@@ -181,10 +177,9 @@ useHead(meta);
           />
         </div>
       </div>
-      <hr />
       <div class="licenses">
-        <h3 class="font-bold">Licenses</h3>
-        <div class="flex flex-col gap-2">
+        <h3 class="font-bold mb-1">Licenses</h3>
+        <div class="flex flex-col gap-1">
           <InputCheckbox v-for="license in backendData.licenses" :key="license" v-model="filters.licences" :value="license" :label="license" />
         </div>
       </div>
@@ -196,9 +191,3 @@ useHead(meta);
 meta:
   layout: wide
 </route>
-
-<style lang="css" scoped>
-.big-box-shadow {
-  box-shadow: 0 0 10px 0 #004ee99e;
-}
-</style>

--- a/frontend-new/src/pages/index.vue
+++ b/frontend-new/src/pages/index.vue
@@ -111,7 +111,7 @@ useHead(meta);
       <!-- Text Input -->
       <input
         v-model="query"
-        class="rounded-l-md p-4 basis-full"
+        class="rounded-l-md p-4 basis-full min-w-0"
         type="text"
         :placeholder="i18n.t('hangar.projectSearch.query', [projects?.pagination.count])"
       />
@@ -119,7 +119,7 @@ useHead(meta);
       <Menu>
         <MenuButton class="bg-gradient-to-r from-[#004ee9] to-[#367aff] rounded-r-md text-left font-semibold flex items-center gap-2 text-white p-2">
           <span class="whitespace-nowrap">{{ i18n.t("hangar.projectSearch.sortBy") }}</span>
-          <icon-mdi-sort-variant class="text-2xl pointer-events-none" />
+          <icon-mdi-sort-variant class="text-xl pointer-events-none" />
         </MenuButton>
         <transition
           enter-active-class="transition duration-100 ease-out"


### PR DESCRIPTION
- Cleaned up many unnecessary css classes
- The Search bar (Along the h2 and Alert) are now inside a container resulting to more consistent layout

### Search Bar
- Now uses `max-w-screen-md` for max width
- Fixed sort button text wrapping causing inconsistent search bar height
- Changed the custom drop shadow to a tailwind provided one.
- Should behave less wonky overall

Before:
<img width="976" alt="image" src="https://user-images.githubusercontent.com/44451855/166718038-02c3dfda-e8a9-47b4-ad24-53a174e76fbb.png">

After:
<img width="992" alt="image" src="https://user-images.githubusercontent.com/44451855/166722514-1e3661d1-3bff-473f-91ee-db76802ca7fa.png">



### Sidebar
- Adjusted some padding for better readability and more compact layout
- Removed the `<hr />` elements for more cleaner look.

Before:
<img width="339" alt="image" src="https://user-images.githubusercontent.com/44451855/166718222-87b0c371-97ab-44a7-833d-62645100d942.png">

After:
<img width="331" alt="image" src="https://user-images.githubusercontent.com/44451855/166718308-43104a4f-1003-4171-85ca-7422610652e7.png">
