### PR TITLE
Fix sidebar height grow

### DIFF
--- a/frontend-new/src/pages/index.vue
+++ b/frontend-new/src/pages/index.vue
@@ -140,7 +140,7 @@ useHead(meta);
       </Menu>
     </div>
   </Container>
-  <Container class="mt-5" lg="flex gap-6">
+  <Container class="mt-5" lg="flex items-start gap-6">
     <!-- Projects -->
     <div class="w-full min-w-0 mb-5" lg="mb-0">
       <ProjectList :projects="projects" />


### PR DESCRIPTION
Before when the projects took up more vertical space than the sidebar, the sidebar would grow height. This fixes that.

**Before:**
<img width="1318" alt="image" src="https://user-images.githubusercontent.com/44451855/169699373-8025627d-6021-457b-8382-58970ac05f8c.png">

**After:**
<img width="1318" alt="image" src="https://user-images.githubusercontent.com/44451855/169699360-b813abf1-15ee-45ea-867f-42b49c8145c3.png">
