### PR TITLE
Use gap for project list spacing

### DIFF
--- a/frontend-new/src/components/projects/ProjectList.vue
+++ b/frontend-new/src/components/projects/ProjectList.vue
@@ -20,7 +20,7 @@ const props = defineProps({
 </script>
 
 <template>
-  <Card v-for="project in projects?.result" :key="project.name" class="flex mb-1 space-x-4">
+  <Card v-for="project in projects?.result" :key="project.name" class="flex space-x-4">
     <div>
       <UserAvatar
         :username="project.namespace.owner"
@@ -39,12 +39,12 @@ const props = defineProps({
     </div>
     <div class="flex-grow"></div>
     <div class="<sm:hidden flex flex-col flex-shrink-0 min-w-40">
-      <span class="inline-flex items-center"
-        ><IconMdiStar class="mx-1" /> {{ project.stats.stars }} {{ i18n.t("project.info.stars", project.stats.stars) }}</span
-      >
-      <span class="inline-flex items-center"
-        ><IconMdiDownload class="mx-1" /> {{ project.stats.downloads }} {{ i18n.t("project.info.totalDownloads", project.stats.downloads) }}</span
-      >
+      <span class="inline-flex items-center">
+        <IconMdiStar class="mx-1" /> {{ project.stats.stars }} {{ i18n.t("project.info.stars", project.stats.stars) }}
+      </span>
+      <span class="inline-flex items-center">
+        <IconMdiDownload class="mx-1" /> {{ project.stats.downloads }} {{ i18n.t("project.info.totalDownloads", project.stats.downloads) }}
+      </span>
       <Tooltip :content="i18n.t('project.info.lastUpdatedTooltip', [i18n.d(project.lastUpdated, 'datetime')])">
         <span class="inline-flex items-center"><IconMdiCalendar class="mx-1" />{{ lastUpdated(project.lastUpdated) }}</span>
       </Tooltip>

--- a/frontend-new/src/pages/index.vue
+++ b/frontend-new/src/pages/index.vue
@@ -142,7 +142,7 @@ useHead(meta);
   </Container>
   <Container class="mt-5" lg="flex items-start gap-6">
     <!-- Projects -->
-    <div class="w-full min-w-0 mb-5" lg="mb-0">
+    <div class="w-full min-w-0 mb-5 flex flex-col gap-2" lg="mb-0">
       <ProjectList :projects="projects" />
     </div>
     <!-- Sidebar -->


### PR DESCRIPTION
Use `gap` property for spacing instead of `margin-bottom`.
Also increase the gap between the projects to 2 units instead of 1.