### PR TITLE
better pinned versions

### DIFF
--- a/frontend/src/components/Tag.vue
+++ b/frontend/src/components/Tag.vue
@@ -49,7 +49,7 @@ const ccColor = computed(() => {
 </script>
 
 <template>
-  <div class="tags inline-flex flex-wrap items-center justify-start p-1">
+  <div class="tags inline-flex flex-wrap items-center justify-start">
     <span
       :style="{
         color: ccColor?.foreground,

--- a/frontend/src/pages/[user]/[project]/index.vue
+++ b/frontend/src/pages/[user]/[project]/index.vue
@@ -109,7 +109,7 @@ useHead(useSeo(props.project.name, props.project.description, route, projectIcon
                   <div class="flex flex-col">
                     <div v-for="(v, p) in version.platformDependencies" :key="p" class="flex flex-row items-center">
                       <PlatformLogo :key="p" :platform="p" :size="24" class="ml-1" />
-                      <span :key="v" class="text-sm text-gray-600">{{ formatVersionNumbers(v) }}</span>
+                      <span :key="v" class="text-sm light:text-gray-600">{{ formatVersionNumbers(v) }}</span>
                     </div>
                   </div>
                 </div>

--- a/frontend/src/pages/[user]/[project]/index.vue
+++ b/frontend/src/pages/[user]/[project]/index.vue
@@ -107,7 +107,7 @@ useHead(useSeo(props.project.name, props.project.description, route, projectIcon
                 <div class="inline-flex items-center">
                   <Tag :name="version.channel.name" :color="{ background: version.channel.color }" />
                   <div class="flex flex-col">
-                    <div v-for="(v, p) in version.platformDependencies" :key="p" class="flex flex-row">
+                    <div v-for="(v, p) in version.platformDependencies" :key="p" class="flex flex-row items-center">
                       <PlatformLogo :key="p" :platform="p" :size="24" class="ml-1" />
                       <span :key="v" class="text-sm text-gray-600">{{ formatVersionNumbers(v) }}</span>
                     </div>
@@ -115,7 +115,7 @@ useHead(useSeo(props.project.name, props.project.description, route, projectIcon
                 </div>
               </router-link>
             </div>
-            <div class="items-center inline-flex ml-1">
+            <div class="items-end inline-flex ml-1">
               <DownloadButton :project="project" :pinned-version="version" small></DownloadButton>
             </div>
           </li>

--- a/frontend/src/pages/[user]/[project]/index.vue
+++ b/frontend/src/pages/[user]/[project]/index.vue
@@ -106,8 +106,12 @@ useHead(useSeo(props.project.name, props.project.description, route, projectIcon
                 <br />
                 <div class="inline-flex items-center">
                   <Tag :name="version.channel.name" :color="{ background: version.channel.color }" />
-                  <PlatformLogo v-for="(v, p) in version.platformDependencies" :key="p" :platform="p" :size="24" class="ml-1" />
-                  <span v-for="v in version.platformDependencies" :key="v" class="text-sm text-gray-600">{{ formatVersionNumbers(v) }}</span>
+                  <div class="flex flex-col">
+                    <div v-for="(v, p) in version.platformDependencies" :key="p" class="flex flex-row">
+                      <PlatformLogo :key="p" :platform="p" :size="24" class="ml-1" />
+                      <span :key="v" class="text-sm text-gray-600">{{ formatVersionNumbers(v) }}</span>
+                    </div>
+                  </div>
                 </div>
               </router-link>
             </div>

--- a/frontend/src/pages/[user]/[project]/index.vue
+++ b/frontend/src/pages/[user]/[project]/index.vue
@@ -115,7 +115,7 @@ useHead(useSeo(props.project.name, props.project.description, route, projectIcon
                 </div>
               </router-link>
             </div>
-            <div class="items-end inline-flex ml-1">
+            <div class="items-top inline-flex ml-1">
               <DownloadButton :project="project" :pinned-version="version" small></DownloadButton>
             </div>
           </li>

--- a/frontend/src/pages/[user]/[project]/index.vue
+++ b/frontend/src/pages/[user]/[project]/index.vue
@@ -23,6 +23,7 @@ import { useBackendDataStore } from "~/store/backendData";
 import Tag from "~/components/Tag.vue";
 import PlatformLogo from "~/components/logos/platforms/PlatformLogo.vue";
 import DownloadButton from "~/components/projects/DownloadButton.vue";
+import { formatVersionNumbers } from "~/composables/useVersionHelper";
 
 const props = defineProps<{
   user: User;
@@ -101,11 +102,12 @@ useHead(useSeo(props.project.name, props.project.description, route, projectIcon
           <li v-for="(version, index) in project.pinnedVersions" :key="`${index}-${version.name}`" class="p-1 py-2 flex">
             <div class="flex-grow truncate">
               <router-link :to="createPinnedVersionUrl(version)">
-                {{ version.name }}
+                <span class="font-semibold">{{ version.name }}</span>
                 <br />
                 <div class="inline-flex items-center">
                   <Tag :name="version.channel.name" :color="{ background: version.channel.color }" />
                   <PlatformLogo v-for="(v, p) in version.platformDependencies" :key="p" :platform="p" :size="24" class="ml-1" />
+                  <span v-for="v in version.platformDependencies" :key="v" class="text-sm text-gray-600">{{ formatVersionNumbers(v) }}</span>
                 </div>
               </router-link>
             </div>


### PR DESCRIPTION
Now shows the version number (thus making pinned versions actually useful)

<img width="332" alt="image" src="https://user-images.githubusercontent.com/70709113/178147256-b0ed2947-ad73-4997-b578-b6bc64139f05.png">
