### PR TITLE
Close navigation popup for router links

### DIFF
--- a/frontend/src/components/layout/Header.vue
+++ b/frontend/src/components/layout/Header.vue
@@ -163,7 +163,7 @@ function isRecent(date: string): boolean {
     <nav class="max-w-screen-xl mx-auto flex justify-between px-4 py-2">
       <!-- Left side items -->
       <div class="flex items-center gap-4">
-        <Popover class="relative">
+        <Popover v-slot="{ close }" class="relative">
           <PopoverButton v-slot="{ open }" class="flex">
             <icon-mdi-menu class="transition-transform text-[1.2em]" :class="open ? 'transform rotate-90' : ''" />
           </PopoverButton>
@@ -189,6 +189,7 @@ function isRecent(date: string): boolean {
                     :to="{ name: link.link }"
                     class="flex items-center rounded-md px-6 py-2"
                     hover="text-primary-400 bg-primary-0"
+                    @click="close()"
                   >
                     <component :is="link.icon" class="mr-3 text-[1.2em]" />
                     {{ link.label }}


### PR DESCRIPTION
When nagivating to a on-hanger page, like authors or the resource
guidelines, the nagivation popup is not closed automatically all the
time as the vue-router does not properly focus the new page elements
after routing.

To improve user experience, this commit simply closes the popup navbar
once an on-site link is clicked.
This behaviour is not needed for external links as those leave the
hangar site.