### PR TITLE
Use router#back when aborting new version upload

### DIFF
--- a/frontend/src/pages/[user]/[project]/versions/new.vue
+++ b/frontend/src/pages/[user]/[project]/versions/new.vue
@@ -47,6 +47,10 @@ const steps: Step[] = [
     beforeNext: async () => {
       return createPendingVersion();
     },
+    beforeBack: async () => {
+      router.back();
+      return false; // Prevent routing by returning false.
+    },
     disableNext: computed(() => file.value == null && url.value == null),
   },
   {


### PR DESCRIPTION
When pressing the abort button while uploading a new version located at
the artifact upload step, hangar would attempt to move one step
backwards again.

To prevent this, the first step of the version creation logic simply
prevents movement backwards and instead triggers a router#back call,
returning to the original version page of the project.

This approach was chosen over an edit of the Steps component itself as
this logic is very unique to each usage of the Steps component. Some may
simply revert to a specific home page, others might use the router#back
function like here while some components might introduce more complex
behaviour.
Additionally, adding a new prop that defines logic to run on abort seems
overkill as other usages, such as the projects/new component simply do
not show a back/abort button.

# Comments
As noted on discord, this could also be implemented with a custom property on the Steps component that handles how the Steps component should behave once it attempts to go back on its first component.
As right now only a single component, versions/new, even has abort logic, this seems overkill compared to a simple two-line function on the pre-back for the first component.