### PR TITLE
Configure vue-router to scroll to top

### DIFF
--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -13,6 +13,7 @@ import { settingsLog } from "~/lib/composables/useLog";
 import * as domain from "~/composables/useDomain";
 
 import "regenerator-runtime/runtime"; // popper needs this?
+import { RouterScrollBehavior } from "vue-router";
 
 const routes = setupLayouts(generatedRoutes);
 // we need to override the path on the error route to have the patch math
@@ -23,10 +24,17 @@ if (errorRoute) {
   console.error("No error route?!");
 }
 
+const scrollBehavior: RouterScrollBehavior = (to, from, savedPosition) => {
+  return savedPosition ? savedPosition : { top: 0 };
+};
+
 const options: Parameters<typeof viteSSR>["1"] = {
   routes,
   pageProps: {
     passToPage: false,
+  },
+  routerOptions: {
+    scrollBehavior,
   },
   transformState(state) {
     return import.meta.env.SSR ? devalue(state) : state;


### PR DESCRIPTION
Up till now, the vue-router did not have any scroll behaviour, leading
to no scrolling on page changes. This becomes particularly obvious when
opening a project from bottom of the main project list, as the project
page is scrolled down to a good part of the README.md.

To fix this, this commit configures the routers scrollBehaviour
following the vuejs documentation to create the most native scrolling
behaviour possible, scrolling to any potentially saved position when
using the browsers back button or scrolling to the top of the page
otherwise.

See: https://router.vuejs.org/guide/advanced/scroll-behavior.html


## Comparison

### Old
[old.webm](https://user-images.githubusercontent.com/32834385/180044549-96156342-7561-4f89-8350-fa77217f110f.webm)

### New
[new.webm](https://user-images.githubusercontent.com/32834385/180044576-edd93dfe-e018-4dec-99e8-9a53b9f74d4c.webm)

