### PR TITLE
Prevent vue from reusing project page component

### DIFF
--- a/frontend/src/components/projects/ProjectPageMarkdown.vue
+++ b/frontend/src/components/projects/ProjectPageMarkdown.vue
@@ -1,0 +1,27 @@
+<script setup lang="ts">
+import { HangarProject } from "hangar-internal";
+import { useI18n } from "vue-i18n";
+import { useRoute, useRouter } from "vue-router";
+import { useProjectPage } from "~/composables/useProjectPage";
+import { useContext } from "vite-ssr";
+import { useHead } from "@vueuse/head";
+import { useSeo } from "~/composables/useSeo";
+
+const props = defineProps<{
+  project: HangarProject;
+}>();
+
+const route = useRoute();
+const router = useRouter();
+const ctx = useContext();
+const i18n = useI18n();
+
+const { editingPage, changeEditingPage, page, savePage, deletePage } = await useProjectPage(route, router, ctx, i18n, props.project);
+if (page) {
+  useHead(useSeo(page.value?.name, props.project.description, route, null));
+}
+</script>
+
+<template>
+  <slot :page="page" :save-page="savePage" :delete-page="deletePage" :editing-page="editingPage" :change-editing-page="changeEditingPage"></slot>
+</template>

--- a/frontend/src/composables/useOpenProjectPages.ts
+++ b/frontend/src/composables/useOpenProjectPages.ts
@@ -1,0 +1,27 @@
+import { RouteLocationNormalizedLoaded } from "vue-router";
+import { HangarProject } from "hangar-internal";
+import { ref, watch } from "vue";
+
+export async function useOpenProjectPages(route: RouteLocationNormalizedLoaded, project: HangarProject) {
+  const open = ref<string[]>([]);
+
+  watch(
+    route,
+    () => {
+      const slugs = route.fullPath.split("/").slice(4);
+      if (slugs.length) {
+        for (let i = 0; i < slugs.length; i++) {
+          const slug = slugs.slice(0, i + 1).join("/");
+          if (!open.value.includes(slug)) {
+            open.value.push(slug);
+          }
+        }
+      } else if (project.pages.length === 1) {
+        open.value.push(project.pages[0].slug);
+      }
+    },
+    { immediate: true }
+  );
+
+  return open;
+}

--- a/frontend/src/composables/useProjectPage.ts
+++ b/frontend/src/composables/useProjectPage.ts
@@ -1,4 +1,4 @@
-import { ref, watch } from "vue";
+import { ref } from "vue";
 import { useInternalApi } from "~/composables/useApi";
 import { handleRequestError } from "~/composables/useErrorHandling";
 import { RouteLocationNormalizedLoaded, Router } from "vue-router";
@@ -23,25 +23,11 @@ export async function useProjectPage(
   }
 
   const editingPage = ref<boolean>(false);
-  const open = ref<string[]>([]);
 
-  watch(
-    route,
-    () => {
-      const slugs = route.fullPath.split("/").slice(4);
-      if (slugs.length) {
-        for (let i = 0; i < slugs.length; i++) {
-          const slug = slugs.slice(0, i + 1).join("/");
-          if (!open.value.includes(slug)) {
-            open.value.push(slug);
-          }
-        }
-      } else if (project.pages.length === 1) {
-        open.value.push(project.pages[0].slug);
-      }
-    },
-    { immediate: true }
-  );
+  // Helper setter function, v-model cannot directly edit from inside a slot.
+  function changeEditingPage(newValue: boolean) {
+    editingPage.value = newValue;
+  }
 
   async function savePage(content: string) {
     if (!page) return;
@@ -59,5 +45,6 @@ export async function useProjectPage(
     await useInternalApi(`pages/delete/${project.id}/${page.value?.id}`, true, "post").catch((e) => handleRequestError(e, ctx, i18n, "page.new.error.save"));
     await router.replace(`/${route.params.user}/${route.params.project}`);
   }
-  return { editingPage, open, page, savePage, deletePage };
+
+  return { editingPage, changeEditingPage, page, savePage, deletePage };
 }


### PR DESCRIPTION
Previously vue would reuse the project page component when switching
between project pages as the component was not keyed.
This commit fixes this by partially modifying the project page setup.

In the current state both the project page content as well as the list
of opened project pages, used to properly configure the tree views
opened elements, are handled in the same state.
This layout however introduces a rather unfortunate flaw into the logic
which makes this fix a bit larger than a simple :key value.

The openedProjectPages `open` contains state that is expected to outlive
a simple change from one project page to another to properly show the
project page tree. This directly conflicts with the assumptions made
about the rest of the project state, which should be discarded the
displayed project page is changed as content and potential edit values
are no longer applicable.

To implement this, this commit splits the opened project pages array
into its own composable as well as the project page markdown into its
own component.

The opened project pages are then tracked by the owning route, e.g. the
prjects index route or the general page route, while the current page
markdown lives in a new component which owns its own state and is keyed
with the pages path.
This way, a change in route properly re-creates the project page
markdown component while keeping the same opened page state in the
parent component.

# Comments

This could also be solved with less diff by actively updating the page content on route change, however I personally believe it does not make much sense to keep the page markdown state in the parent component of either the [...all].vue or the index.vue.