### PR TITLE
Disable next button on incorrect new version data

### DIFF
--- a/frontend/src/pages/[user]/[project]/versions/new.vue
+++ b/frontend/src/pages/[user]/[project]/versions/new.vue
@@ -87,6 +87,11 @@ const steps: Step[] = [
     beforeNext: async () => {
       return createVersion();
     },
+    disableNext: computed(() => {
+      return changelogRules.some((v) => {
+        return !v.$validator(descriptionEditor.value?.rawEdited ?? "", undefined, undefined);
+      });
+    }),
   },
 ];
 

--- a/frontend/src/pages/[user]/[project]/versions/new.vue
+++ b/frontend/src/pages/[user]/[project]/versions/new.vue
@@ -47,7 +47,10 @@ const steps: Step[] = [
     beforeNext: async () => {
       return createPendingVersion();
     },
-    disableNext: computed(() => file.value == null && url.value == null),
+    disableNext: computed(() => {
+      const currentNonNullURLValue = url.value ?? "";
+      return file.value == null && (currentNonNullURLValue === "" || !validUrl().$validator(currentNonNullURLValue, undefined, undefined));
+    }),
   },
   {
     value: "basic",
@@ -56,6 +59,7 @@ const steps: Step[] = [
       await preload();
       return true;
     },
+    disableNext: computed(() => (selectedPlatforms.value?.length ?? 0) < 1),
   },
   { value: "dependencies", header: t("version.new.steps.3.header") },
   {
@@ -313,7 +317,7 @@ useHead(
       <MarkdownEditor
         ref="descriptionEditor"
         class="mt-2"
-        :raw="pendingVersion.description"
+        :raw="pendingVersion?.description ?? ''"
         editing
         :deletable="false"
         :cancellable="false"


### PR DESCRIPTION
When uploading a new version of a project to hangar, the next buttons in
the steps screens 'Artifact' and 'Basic Info' are not greyed out even if
invalid data is currently present in the form.

Specifically, the next button in the 'Artifact' screen is visible usable
even if the current url is not a valid url.
Additionally, the next button in the 'Basic Info' step is visible
usable, (and logically usable), even without a single platform selected,
leading to project creation errors down the line.

Beyond that, this commit also fixes a slight oversite in which the
description was able to simply pass null as the raw prop of the markdown
editor instead of an empty string, resulting in a client side error.