### PR TITLE
Prevent Steps#next on final version creation step

### DIFF
--- a/frontend/src/pages/[user]/[project]/versions/new.vue
+++ b/frontend/src/pages/[user]/[project]/versions/new.vue
@@ -62,7 +62,8 @@ const steps: Step[] = [
     value: "changelog",
     header: t("version.new.steps.4.header"),
     beforeNext: async () => {
-      return createVersion();
+      await createVersion();
+      return false; // createVersion already hijacks the beforeNext logic, cannot move next on final step.
     },
   },
 ];
@@ -147,7 +148,7 @@ async function createPendingVersion() {
 
 async function createVersion() {
   if (!pendingVersion.value) {
-    return false;
+    return;
   }
 
   loading.submit = true;
@@ -177,10 +178,8 @@ async function createVersion() {
   try {
     await useInternalApi(`versions/version/${props.project.id}/create`, true, "post", pendingVersion.value);
     await router.push(`/${route.params.user}/${route.params.project}/versions`);
-    return true;
   } catch (e: any) {
     handleRequestError(e, ctx, i18n);
-    return false;
   } finally {
     loading.submit = false;
   }


### PR DESCRIPTION
Different than the project creation usage of the Steps component, which
adds a proper final creation button, the version creation page simply
uses the beforeNext function of the final step to create the version and
route the client to the version overview.

Previously however, this logic would still instruct the Steps component
to move forward to the next step if the creation succeeded. However this
raises an index out of bounds exception, as this logic runs on the last
step.

To prevent this, this commit always disallows movement to the next,
non-existing, step and simply lets the router call in the beforeNext
method take care of routing.

# Comments
This issue is similar to the one fixed by #768 or HangarMC/HangarLib#3 respectively, however there is absolutely no fitting behavior for a general use-case like `router.back()` served in the mentioned similar issue.

One potentially cleaner way would be to rewrite the steps component to actively define a finalization logic.
I personally would probably be in favour of that, however the project creation would then have to be re-written partially in its last step.
Feel free to provide some feedback here, I'd be happy to change it to the previously mentioned alternative. 