### PR TITLE
Create tokens with same-site policy lax

### DIFF
--- a/src/main/java/io/papermc/hangar/service/TokenService.java
+++ b/src/main/java/io/papermc/hangar/service/TokenService.java
@@ -61,7 +61,7 @@ public class TokenService extends HangarComponent {
     }
 
     private void addCookie(String name, String value, long maxAge, boolean httpOnly) {
-        response.addHeader(HttpHeaders.SET_COOKIE, ResponseCookie.from(name, value).path("/").secure(config.security.isSecure()).maxAge(maxAge).sameSite("Strict").httpOnly(httpOnly).build().toString());
+        response.addHeader(HttpHeaders.SET_COOKIE, ResponseCookie.from(name, value).path("/").secure(config.security.isSecure()).maxAge(maxAge).sameSite("Lax").httpOnly(httpOnly).build().toString());
     }
 
     public void refreshAccessToken(String refreshToken) {


### PR DESCRIPTION
Both the HangarAuth and HangarAuth_REFRESH cookies were set with
same-site policy 'strict', preventing the browser from sending them when
opening a hangar page from a third party href, such as a plain link in a
github gist.

This prevents the server side rendering from picking up the token or
refresh token, leading the the server side rendering logic to assume an
unauthorized user is attempting to view a page eventho the user is
actually logged in.
This directly leads to hydration errors as the SSR renders the page for
a non-logged in user while the client side hydration properly detects
the logged in user and renders a potentially completely different page.

# Notes for testing
You may have to delete your cookies for the hangar staging/local hangar setup so that it is properly refreshed and updated with the new same-site policy.