### PR TITLE
Sanitize trailing slashes from project page urls

### DIFF
--- a/frontend/src/composables/useProjectPage.ts
+++ b/frontend/src/composables/useProjectPage.ts
@@ -15,7 +15,8 @@ export async function useProjectPage(
   i18n: Composer<unknown, unknown, unknown, VueMessageType>,
   project: HangarProject
 ) {
-  const page = await usePage(route.params.user as string, route.params.project as string, route.params.all as string).catch((e) =>
+  const sanitizedProjectPageSlug = (route.params.all as string).replace(/\/+$/, "");
+  const page = await usePage(route.params.user as string, route.params.project as string, sanitizedProjectPageSlug).catch((e) =>
     handleRequestError(e, ctx, i18n)
   );
   if (!page) {


### PR DESCRIPTION
While looking up a project page, the frontend may be passing in a path
that contains a trailing slash. For example
'page/user/project/pages/ExamplePage/'.

This, prior to this commit, yielded a 404 not found response which in
turn messed with SSR.

To prevent this, the hangar frontend now actively sanitizes the url
before requesting the page from the backend.

# Notes
This could also technically live in the general request logic to strip any trailing slashes there.
If we wanted to, I presume even on the backend side of things.
Open for opinions.