### PR TITLE
Properly scroll to linked element if present

### DIFF
--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -25,7 +25,13 @@ if (errorRoute) {
 }
 
 const scrollBehavior: RouterScrollBehavior = (to, from, savedPosition) => {
-  return savedPosition ? savedPosition : { top: 0 };
+  if (savedPosition) {
+    return savedPosition;
+  } else if (to.hash) {
+    return { el: to.hash };
+  } else {
+    return { top: 0 };
+  }
 };
 
 const options: Parameters<typeof viteSSR>["1"] = {


### PR DESCRIPTION
The recent fix for scroll behaviour in the vue-router always scrolls the
page to the top when no saved position is found. This however introduced
a regression in regards to section references in the html, such as
https://hangar.benndorf.dev/lynxplay/testing-staging-css#lists.

To fix this, the router scroll behaviour now properly checks for and
uses any existing element hash in the route before defaulting back to
the simple scoll-to-top behaviour.

See: #769