### PR TITLE
Disable role selector buttons when no role is selected

### DIFF
--- a/frontend/src/pages/admin/user/[user].vue
+++ b/frontend/src/pages/admin/user/[user].vue
@@ -139,10 +139,10 @@ useHead(useSeo(i18n.t("userAdmin.title") + " " + route.params.user, null, route,
           <InputSelect v-model="selectedRole" :values="backendData.globalRoles" item-text="title" item-value="value"></InputSelect>
         </div>
         <div>
-          <Button size="medium" @click="processRole(true)">{{ i18n.t("general.add") }}</Button>
+          <Button size="medium" :disabled="!selectedRole" @click="processRole(true)">{{ i18n.t("general.add") }}</Button>
         </div>
         <div class="ml-4">
-          <Button size="medium" @click="processRole(false)">{{ i18n.t("general.delete") }}</Button>
+          <Button size="medium" :disabled="!selectedRole" @click="processRole(false)">{{ i18n.t("general.delete") }}</Button>
         </div>
       </div>
     </Card>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/23108066/180848499-8d820bc4-b018-4e2c-a3d1-057f434ac70d.png)

Before it still let you press it even without a role selected, this caused it to try to pass undefined. 