### PR TITLE
Remove invalid versions when filtering platforms

### DIFF
--- a/frontend/src/pages/index.vue
+++ b/frontend/src/pages/index.vue
@@ -89,6 +89,15 @@ function versions(platform: Platform) {
   });
 }
 
+function updatePlatform(platform: any) {
+  filters.value.platform = platform;
+
+  const allowedVersion = versions(platform);
+  filters.value.versions = filters.value.versions.filter((existingVersion) => {
+    return allowedVersion.find((allowedNewVersion) => allowedNewVersion.version === existingVersion);
+  });
+}
+
 const meta = useSeo("Home", null, route, null);
 const script = {
   type: "application/ld+json",
@@ -167,7 +176,7 @@ useHead(meta);
         <div class="flex flex-col gap-1">
           <ul>
             <li v-for="platform in backendData.visiblePlatforms" :key="platform.enumName" class="inline-flex w-full">
-              <InputRadio v-model="filters.platform" :value="platform.enumName" :label="platform.name">
+              <InputRadio :label="platform.name" :model-value="filters.platform" :value="platform.enumName" @update:modelValue="updatePlatform">
                 <PlatformLogo :platform="platform.enumName" :size="24" class="mr-1" />
               </InputRadio>
             </li>


### PR DESCRIPTION
When users filter the available projects by platform and versions,
switching the platform, prior to this commit, does not remove versions
no available on the platform selected.

This leads to empty return queries, e.g. when a user first selects
version 1.19 while filtering for the paper platform and then switching
to the velocity view, which simply does not have a 1.19 version.

This commit fixes this faulty behaviour by removing versions that are
not available in the platform filtered by. Versions that match, which is
usually the case when switching between paper and waterfall, are kept as
a general improvement to user experience compared to always clearing the
versions selected.