### PR TITLE
Update fetched project page tree on mutation

### DIFF
--- a/frontend/src/components/modals/NewPageModal.vue
+++ b/frontend/src/components/modals/NewPageModal.vue
@@ -5,7 +5,7 @@ import Modal from "~/lib/components/modals/Modal.vue";
 import { useBackendDataStore } from "~/store/backendData";
 import { useContext } from "vite-ssr/vue";
 import { HangarProjectPage } from "hangar-internal";
-import { computed, ref, watch } from "vue";
+import { computed, inject, ref, watch } from "vue";
 import InputText from "~/lib/components/ui/InputText.vue";
 import InputSelect, { Option } from "~/lib/components/ui/InputSelect.vue";
 import { useInternalApi } from "~/composables/useApi";
@@ -23,6 +23,8 @@ const ctx = useContext();
 const route = useRoute();
 const router = useRouter();
 const backendData = useBackendDataStore();
+
+const updateProjectPagesCallback = inject<(pages: HangarProjectPage[]) => void>("updateProjectPages");
 
 const pageRoots = computed(() => flatDeep(props.pages, ""));
 const name = ref("");
@@ -69,6 +71,11 @@ async function createPage() {
       name: name.value,
       parentId: parent.value,
     });
+
+    if (updateProjectPagesCallback) {
+      updateProjectPagesCallback(await useInternalApi<HangarProjectPage[]>(`pages/list/${props.projectId}`, false, "get"));
+    }
+
     await router.push(`/${route.params.user}/${route.params.project}/pages/${slug}`);
   } catch (e) {
     handleRequestError(e, ctx, i18n);

--- a/frontend/src/components/projects/ProjectPageMarkdown.vue
+++ b/frontend/src/components/projects/ProjectPageMarkdown.vue
@@ -8,6 +8,7 @@ import { useHead } from "@vueuse/head";
 import { useSeo } from "~/composables/useSeo";
 import { inject } from "vue";
 import { useInternalApi } from "~/composables/useApi";
+import {handleRequestError} from "~/composables/useErrorHandling";
 
 const props = defineProps<{
   project: HangarProject;
@@ -28,8 +29,12 @@ if (page) {
 async function deletePageAndUpdateProject() {
   await deletePage();
 
-  if (updateProjectPages) {
-    updateProjectPages(await useInternalApi<HangarProjectPage[]>(`pages/list/${props.project.id}`, false, "get"));
+  try {
+    if (updateProjectPages) {
+      updateProjectPages(await useInternalApi<HangarProjectPage[]>(`pages/list/${props.project.id}`, false, "get"));
+    }
+  } catch (e: any) {
+    handleRequestError(e, ctx, i18n);
   }
 }
 </script>

--- a/frontend/src/components/projects/ProjectPageMarkdown.vue
+++ b/frontend/src/components/projects/ProjectPageMarkdown.vue
@@ -1,11 +1,13 @@
 <script setup lang="ts">
-import { HangarProject } from "hangar-internal";
+import { HangarProject, HangarProjectPage } from "hangar-internal";
 import { useI18n } from "vue-i18n";
 import { useRoute, useRouter } from "vue-router";
 import { useProjectPage } from "~/composables/useProjectPage";
 import { useContext } from "vite-ssr";
 import { useHead } from "@vueuse/head";
 import { useSeo } from "~/composables/useSeo";
+import { inject } from "vue";
+import { useInternalApi } from "~/composables/useApi";
 
 const props = defineProps<{
   project: HangarProject;
@@ -16,12 +18,28 @@ const router = useRouter();
 const ctx = useContext();
 const i18n = useI18n();
 
+const updateProjectPages = inject<(pages: HangarProjectPage[]) => void>("updateProjectPages");
+
 const { editingPage, changeEditingPage, page, savePage, deletePage } = await useProjectPage(route, router, ctx, i18n, props.project);
 if (page) {
   useHead(useSeo(page.value?.name, props.project.description, route, null));
 }
+
+async function deletePageAndUpdateProject() {
+  await deletePage();
+
+  if (updateProjectPages) {
+    updateProjectPages(await useInternalApi<HangarProjectPage[]>(`pages/list/${props.project.id}`, false, "get"));
+  }
+}
 </script>
 
 <template>
-  <slot :page="page" :save-page="savePage" :delete-page="deletePage" :editing-page="editingPage" :change-editing-page="changeEditingPage"></slot>
+  <slot
+    :page="page"
+    :save-page="savePage"
+    :delete-page="deletePageAndUpdateProject"
+    :editing-page="editingPage"
+    :change-editing-page="changeEditingPage"
+  ></slot>
 </template>

--- a/frontend/src/pages/[user]/[project].vue
+++ b/frontend/src/pages/[user]/[project].vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { PropType } from "vue";
+import { PropType, provide } from "vue";
 import { User } from "hangar-api";
 import { useContext } from "vite-ssr/vue";
 import { useI18n } from "vue-i18n";
@@ -12,6 +12,7 @@ import ProjectNav from "~/components/projects/ProjectNav.vue";
 import { useHead } from "@vueuse/head";
 import { useSeo } from "~/composables/useSeo";
 import { projectIconUrl } from "~/composables/useUrlHelper";
+import { HangarProject, HangarProjectPage } from "hangar-internal";
 
 defineProps({
   user: {
@@ -29,6 +30,10 @@ if (!project || !project.value) {
 } else {
   useHead(useSeo(project.value.name, project.value.description, route, projectIconUrl(project.value.namespace.owner, project.value.namespace.slug)));
 }
+
+provide("updateProjectPages", function (pages: HangarProjectPage[]) {
+  if (project && project.value) project.value.pages = pages;
+});
 </script>
 
 <template>
@@ -37,7 +42,7 @@ if (!project || !project.value) {
     <ProjectNav :project="project"></ProjectNav>
     <router-view v-slot="{ Component }">
       <Suspense>
-        <component :is="Component" :user="user" :project="project" />
+        <component :is="Component" v-model:project="project" :user="user" />
         <template #fallback> Loading... </template>
       </Suspense>
     </router-view>

--- a/src/main/java/io/papermc/hangar/controller/internal/projects/ProjectPageController.java
+++ b/src/main/java/io/papermc/hangar/controller/internal/projects/ProjectPageController.java
@@ -7,6 +7,7 @@ import io.papermc.hangar.model.common.PermissionType;
 import io.papermc.hangar.model.internal.api.requests.StringContent;
 import io.papermc.hangar.model.internal.api.requests.projects.NewProjectPage;
 import io.papermc.hangar.model.internal.projects.ExtendedProjectPage;
+import io.papermc.hangar.model.internal.projects.HangarProjectPage;
 import io.papermc.hangar.security.annotations.Anyone;
 import io.papermc.hangar.security.annotations.permission.PermissionRequired;
 import io.papermc.hangar.security.annotations.ratelimit.RateLimit;
@@ -32,6 +33,7 @@ import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
 import javax.validation.Valid;
+import java.util.Collection;
 
 @Anyone
 @Controller
@@ -86,6 +88,14 @@ public class ProjectPageController extends HangarComponent {
     @GetMapping(path = "/page/{author}/{slug}/**", produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<ExtendedProjectPage> getProjectPage(@PathVariable String author, @PathVariable String slug) {
         return ResponseEntity.ok(projectPageService.getProjectPage(author, slug, request.getRequestURI()));
+    }
+
+    @Unlocked
+    @RateLimit(overdraft = 5, refillTokens = 1, refillSeconds = 20)
+    @GetMapping(value = "/list/{projectId}")
+    @ResponseStatus(HttpStatus.OK)
+    public ResponseEntity<Collection<HangarProjectPage>> listProjectPages(@PathVariable final long projectId) {
+        return ResponseEntity.ok(projectPageService.getProjectPages(projectId).values());
     }
 
     @Unlocked


### PR DESCRIPTION
When a new project page is added or removed to or from the project, the
frontend does not completely reload the project, which is fine. However
this means that, until a complete page reload is invoked, the pages in
the project page tree will not reflect the new page structure of the
project.

To fix this, this commit defines a new provider on the root project page
that provides a simple update function taking in the new project page
array.

Child components way down the tree, specifically the NewPageModel and
the ProjectPageMarkdown component then inject said update function and
feed it the new page layout fetched from the backend on project page
index mutation.

Resolves: #713