### PR TITLE
Ensure that the new page modal is closed

### DIFF
--- a/frontend/src/components/modals/NewPageModal.vue
+++ b/frontend/src/components/modals/NewPageModal.vue
@@ -25,6 +25,7 @@ const router = useRouter();
 const backendData = useBackendDataStore();
 
 const updateProjectPagesCallback = inject<(pages: HangarProjectPage[]) => void>("updateProjectPages");
+const modal = ref<any | null>(null); // Filled by vue
 
 const pageRoots = computed(() => flatDeep(props.pages, ""));
 const name = ref("");
@@ -81,11 +82,13 @@ async function createPage() {
     handleRequestError(e, ctx, i18n);
   }
   loading.value = false;
+
+  modal.value?.close();
 }
 </script>
 
 <template>
-  <Modal :title="i18n.t('page.new.title')" window-classes="w-120">
+  <Modal ref="modal" :title="i18n.t('page.new.title')" window-classes="w-120">
     <div class="flex flex-col">
       <InputText
         v-model.trim="name"


### PR DESCRIPTION
While the modal registers a click listener on the slot itself, the
create button overtakes the click behaviour. To still properly close the
modal, this commit now actively calls the close function on the modal
when a new page is created.