### PR TITLE
Use the proper config for page name validation

### DIFF
--- a/src/main/java/io/papermc/hangar/controller/internal/projects/ProjectPageController.java
+++ b/src/main/java/io/papermc/hangar/controller/internal/projects/ProjectPageController.java
@@ -78,9 +78,7 @@ public class ProjectPageController extends HangarComponent {
     @ResponseStatus(HttpStatus.OK)
     @GetMapping("/checkName")
     public void checkName(@RequestParam long projectId, @RequestParam String name, @RequestParam(required = false) Long parentId) {
-        if (!validationService.isValidPageName(name)) {
-            throw new HangarApiException("page.new.error.invalidName");
-        }
+        validationService.testPageName(name);
         projectPageService.checkDuplicateName(projectId, name, parentId);
     }
 

--- a/src/main/java/io/papermc/hangar/service/ValidationService.java
+++ b/src/main/java/io/papermc/hangar/service/ValidationService.java
@@ -1,5 +1,6 @@
 package io.papermc.hangar.service;
 
+import io.papermc.hangar.exceptions.HangarApiException;
 import io.papermc.hangar.service.internal.projects.ProjectFactory;
 import org.jetbrains.annotations.Nullable;
 import org.springframework.stereotype.Service;
@@ -57,14 +58,12 @@ public class ValidationService {
         return true;
     }
 
-    public boolean isValidPageName(String name) {
+    public void testPageName(String name) {
         name = StringUtils.compact(name);
         if (bannedRoutes.contains(name)) {
-            return false;
+            throw new HangarApiException("page.new.error.invalidName");
         }
-        if (name.length() < 1 || name.length() > config.projects.getMaxPageNameLen() || !config.projects.getPageNameMatcher().test(name)) {
-            return false;
-        }
-        return true;
+
+        config.pages.testPageName(name);
     }
 }

--- a/src/main/java/io/papermc/hangar/service/internal/projects/ProjectPageService.java
+++ b/src/main/java/io/papermc/hangar/service/internal/projects/ProjectPageService.java
@@ -12,6 +12,7 @@ import io.papermc.hangar.model.internal.logs.LogAction;
 import io.papermc.hangar.model.internal.logs.contexts.PageContext;
 import io.papermc.hangar.model.internal.projects.ExtendedProjectPage;
 import io.papermc.hangar.model.internal.projects.HangarProjectPage;
+import io.papermc.hangar.service.ValidationService;
 import io.papermc.hangar.service.internal.JobService;
 import io.papermc.hangar.util.StringUtils;
 import org.jetbrains.annotations.Nullable;
@@ -29,11 +30,13 @@ public class ProjectPageService extends HangarComponent {
     private final ProjectPagesDAO projectPagesDAO;
     private final HangarProjectPagesDAO hangarProjectPagesDAO;
     private final JobService jobService;
+    private final ValidationService validationService;
 
-    public ProjectPageService(ProjectPagesDAO projectPagesDAO, HangarProjectPagesDAO hangarProjectPagesDAO, JobService jobService) {
+    public ProjectPageService(ProjectPagesDAO projectPagesDAO, HangarProjectPagesDAO hangarProjectPagesDAO, JobService jobService, final ValidationService validationService) {
         this.projectPagesDAO = projectPagesDAO;
         this.hangarProjectPagesDAO = hangarProjectPagesDAO;
         this.jobService = jobService;
+        this.validationService = validationService;
     }
 
     public void checkDuplicateName(long projectId, String name, @Nullable Long parentId) {
@@ -52,7 +55,7 @@ public class ProjectPageService extends HangarComponent {
             throw new HangarApiException(HttpStatus.BAD_REQUEST, "page.new.error.maxLength");
         }
 
-        config.pages.testPageName(name);
+        validationService.testPageName(name);
 
         checkDuplicateName(projectId, name, parentId);
 


### PR DESCRIPTION
Prior to this commit, hangar would use the project name configuration to
check the page name. This completely ignored the existing configuration
for page names, which already permits spaces and has existing rules
regarding max and min length.

This commit now properly uses said configuration feature when checking
the name of a page that is to be created.