### PR TITLE
Add gitlab.com to safe-download-hosts

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -151,6 +151,7 @@ hangar:
       timeout: 10000
     safe-download-hosts:
       - "github.com"
+      - "gitlab.com"
       - "youtu.be"
       - "youtube.com"
       - "papermc.io"


### PR DESCRIPTION
I heard about `safe-download-hosts` on the Discord server, but noticed `gitlab.com` is missing, which is where I (and I'm sure a bunch of others) am hosting my source code and plugin downloads. Given that `github.com` is in the list, I think it's reasonable to also include `gitlab.com`?

Thanks for your work on Hangar BTW, looking forward to using it for my plugin!