### PR TITLE
Use Eclipse Temurin 17 JRE Alpine

### DIFF
--- a/docker/deployment/hangar-backend/Dockerfile
+++ b/docker/deployment/hangar-backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:17-jdk-alpine
+FROM eclipse-temurin:17-jre-alpine
 
 WORKDIR hangar
 


### PR DESCRIPTION
openjdk:17-jdk-alpine is not being updated. Right now HangarAuth uses an early access build of JDK 17, known to have issues (comes up in paper-help every now and then with some JVM error).

This also switches to JRE as we don't need JDK functionality.