### PR TITLE
Header and Footer improvements

### DIFF
--- a/frontend/src/components/layout/Footer.vue
+++ b/frontend/src/components/layout/Footer.vue
@@ -5,9 +5,9 @@ const { t } = useI18n();
 </script>
 
 <template>
-  <footer class="relative flex items-end mt-10 background-default px-8 pb-2 text-light-10 min-h-10">
-    <div class="w-screen">
-      <div class="flex flex-col gap-4 md:(flex-row-reverse gap-0) items-center justify-around mt-4 max-w-1200px m-auto text-sm">
+  <footer class="relative flex mt-10 background-default px-8 text-light-10">
+    <div class="mt-3 mb-3 flex flex-column flex-grow-1 justify-center">
+      <div class="flex flex-wrap flex-row-reverse flex-grow-1 gap-4 justify-around items-center max-w-1200px text-sm">
         <div class="flex flex-row flex-wrap justify-center">
           <a
             href="https://github.com/HangarMC"

--- a/frontend/src/components/layout/Header.vue
+++ b/frontend/src/components/layout/Header.vue
@@ -159,7 +159,7 @@ function isRecent(date: string): boolean {
       <Announcement v-for="(announcement, idx) in useBackendData.announcements" :key="idx" :announcement="announcement" />
     </div>
 
-    <nav class="max-w-screen-xl mx-auto flex justify-between px-4 py-2">
+    <nav class="max-w-screen-xl mx-auto flex flex-wrap justify-center px-4 py-2 gap-3">
       <!-- Left side items -->
       <div class="flex items-center gap-4">
         <Popover v-slot="{ close }" class="relative">
@@ -245,6 +245,9 @@ function isRecent(date: string): boolean {
           </router-link>
         </div>
       </div>
+
+      <!-- Gap between the sides -->
+      <div class="d-none d-sm-block flex-grow-1" />
 
       <!-- Right side items -->
       <div class="flex items-center gap-2">

--- a/frontend/src/components/layout/Header.vue
+++ b/frontend/src/components/layout/Header.vue
@@ -247,7 +247,7 @@ function isRecent(date: string): boolean {
       </div>
 
       <!-- Gap between the sides -->
-      <div class="d-none d-sm-block flex-grow-1" />
+      <div class="flex-grow-1" />
 
       <!-- Right side items -->
       <div class="flex items-center gap-2">


### PR DESCRIPTION
# Footer

The footer was not aligned properly.

### Before

![Screenshot 2023-02-22 at 04 10 28](https://user-images.githubusercontent.com/81972035/220503622-6c98ed14-a722-4282-8cb2-acc3bd873a31.png)

### After

![Screenshot 2023-02-22 at 04 10 20](https://user-images.githubusercontent.com/81972035/220503700-cf501d0c-e801-4aad-9624-18ef3e857e65.png)

# Header

The header right side items were overlapping the left side items on small phone screen.

### Before

![Screenshot 2023-02-22 at 04 09 58](https://user-images.githubusercontent.com/81972035/220503791-474005bc-7651-4a01-9ecf-c9851222686e.png)

### After

![Screenshot 2023-02-22 at 04 10 03](https://user-images.githubusercontent.com/81972035/220503823-2137d7d8-3e13-4555-950f-22f6e44fd54c.png)