### PR TITLE
Fix hovering on a tooltip

### DIFF
--- a/frontend/src/components/design/Tooltip.vue
+++ b/frontend/src/components/design/Tooltip.vue
@@ -34,6 +34,7 @@ onErrorCaptured((err) => {
 <style>
 .popper {
   --popper-theme-background-color: #464646;
+  --popper-theme-background-color-hover: #464646;
   --popper-theme-padding: 0.5rem;
   --popper-theme-border-radius: 0.375rem;
   --popper-theme-text-color: #fff;


### PR DESCRIPTION
This fixes #1163.

When hovering over a tooltip, the background disappears, in some cases making it difficult to read. I see no reason for the background colour to change when hovering over the tooltip. The easiest fix here is to set the background hover variable to be the same as the existing background, allowing for this to potentially be changed in the future if the behaviour becomes desired.

## Before

https://user-images.githubusercontent.com/1780637/234939938-7b670ca7-f4fe-449f-ba0f-c036fc296b9b.mov

## After


https://user-images.githubusercontent.com/1780637/234941137-720b14f3-6a79-4853-86d2-1194357ee0e8.mov

