### PR TITLE
Add a message to the changelog validation rules

### DIFF
--- a/frontend/src/components/MarkdownEditor.client.vue
+++ b/frontend/src/components/MarkdownEditor.client.vue
@@ -24,6 +24,7 @@ const props = withDefaults(
     rules?: ValidationRule<string | undefined>[];
     noPaddingTop?: boolean;
     maxHeight?: string;
+    label?: string;
   }>(),
   {
     maxlength: 30_000,
@@ -52,7 +53,7 @@ const internalEditing = computed({
 });
 
 const errorMessages = computed(() => props.errorMessages);
-const { v, errors } = useValidation(undefined, props.rules, rawEdited, errorMessages);
+const { v, errors } = useValidation(props.label, props.rules, rawEdited, errorMessages);
 
 if (process.client && props.editing) {
   onMounted(startEditing);

--- a/frontend/src/components/MarkdownEditor.server.vue
+++ b/frontend/src/components/MarkdownEditor.server.vue
@@ -15,6 +15,7 @@ const props = withDefaults(
     rules?: ValidationRule<string | undefined>[];
     noPaddingTop?: boolean;
     maxHeight?: string;
+    label?: string;
   }>(),
   {
     maxlength: 30_000,

--- a/frontend/src/pages/[user]/[project]/versions/[version]/index.vue
+++ b/frontend/src/pages/[user]/[project]/versions/[version]/index.vue
@@ -15,6 +15,7 @@ import { useErrorRedirect } from "~/composables/useErrorRedirect";
 import TagComponent from "~/components/Tag.vue";
 import { hasPerms } from "~/composables/usePerm";
 import Button from "~/components/design/Button.vue";
+import { required } from "~/composables/useValidationHelpers";
 
 import { MarkdownEditor } from "#components";
 import Markdown from "~/components/Markdown.vue";
@@ -184,6 +185,7 @@ async function restoreVersion() {
             :deletable="false"
             :cancellable="true"
             :saveable="true"
+            :rules="[required()]"
             @save="savePage"
           />
           <template #fallback>

--- a/frontend/src/pages/[user]/[project]/versions/new.vue
+++ b/frontend/src/pages/[user]/[project]/versions/new.vue
@@ -407,7 +407,7 @@ useHead(useSeo(i18n.t("version.new.title") + " | " + props.project.name, props.p
         <ClientOnly>
           <MarkdownEditor
             ref="descriptionEditor"
-            :title="t('version.new.form.release.bulletin')"
+            :label="t('version.new.form.release.bulletin')"
             :raw="descriptionToLoad"
             editing
             no-padding-top


### PR DESCRIPTION
When adding a new version previously it would say "val is required". This was due to the `MarkdownEditor` component passing `undefined` as the name.

Since the `title` property of the component is a slot, I've opted to add a new prop the component which is used to populate the field name. The use of the `title` in the new version screen is also invalid, so I have removed it.

I've also added a validation rule to the Edit changelog page as well, since it's required when creating a version, it makes sense for it to be required when editing it. 

## Before

![Screenshot 2023-04-27 at 19 33 45](https://user-images.githubusercontent.com/1780637/234959274-44e95a88-0cd6-41dd-94f4-556dbf18c650.png)

## After

![Screenshot 2023-04-27 at 19 34 57](https://user-images.githubusercontent.com/1780637/234959476-6b575c96-f5ef-470c-a43e-dbd62698279f.png)

