### PR TITLE
Reset the uploaded image when it's too big

### DIFF
--- a/backend/src/main/java/io/papermc/hangar/exceptions/handlers/FileTooLargeExceptionHandler.java
+++ b/backend/src/main/java/io/papermc/hangar/exceptions/handlers/FileTooLargeExceptionHandler.java
@@ -24,7 +24,7 @@ public class FileTooLargeExceptionHandler extends ResponseEntityExceptionHandler
 
     @ExceptionHandler(MultiPartParserDefinition.FileTooLargeException.class)
     public ResponseEntity<HangarApiException> handleException(final MultiPartParserDefinition.FileTooLargeException exception) {
-        final HangarApiException apiException = new HangarApiException(HttpStatus.PAYLOAD_TOO_LARGE, "File too large - files have to be less than " + this.config.projects.maxFileSize() + "MB in size");
+        final HangarApiException apiException = new HangarApiException(HttpStatus.PAYLOAD_TOO_LARGE, "File too large - files have to be less than " + this.config.projects.maxFileSizeMB() + "MB in size");
         return new ResponseEntity<>(apiException, HttpStatus.PAYLOAD_TOO_LARGE);
     }
 

--- a/frontend/src/components/modals/AvatarChangeModal.vue
+++ b/frontend/src/components/modals/AvatarChangeModal.vue
@@ -88,6 +88,7 @@ watch(selectedFile, (newValue) => {
   }
   if (newValue.size >= useBackendData.validations.project.maxFileSize) {
     notifications.error(t("validation.maxFileSize"));
+    selectedFile.value = null;
     return null;
   }
 


### PR DESCRIPTION
When uploading a new avatar, if the image is too big it will notify the user, however it does not reset the uploaded image making it appear like you can continue to upload it. Now it will instead reset the image, making it obvious that the image cannot be uploaded.

The error message when a file was too big also gave the value in bytes, whilst saying it was in MB (reported in #1162). This is also now fixed!