### PR TITLE
Fix inconsistency in the keyword tag entry box

### DIFF
--- a/frontend/src/components/ui/InputTag.vue
+++ b/frontend/src/components/ui/InputTag.vue
@@ -105,13 +105,6 @@ const filteredOptions = computed(() => {
   }
   return props.options;
 });
-
-const tagInput = (event: Event) => {
-  const target = event.target as HTMLInputElement;
-  if (target.value.trim().length < props.tagMaxlength) {
-    tag.value = target.value;
-  }
-};
 </script>
 
 <template>
@@ -136,14 +129,13 @@ const tagInput = (event: Event) => {
       </span>
       <template v-if="options">
         <input
-          :value="tag"
+          v-model="tag"
           type="text"
           v-bind="$attrs"
           :class="slotProps.class"
           :list="id"
           class="pointer-events-auto flex-grow !bg-gray-100 rounded-xl px-2 dark:(!bg-gray-500 text-white)"
           @blur="v.$touch()"
-          @input="tagInput"
           @keydown.enter="add"
           @change="add"
         />
@@ -159,7 +151,7 @@ const tagInput = (event: Event) => {
         :class="slotProps.class"
       >
         <IconMdiSubdirectoryArrowLeft class="absolute right-2"> </IconMdiSubdirectoryArrowLeft>
-        <input :value="tag" type="text" :class="slotProps.class" @keydown.enter="add" @blur="v.$touch()" @input="tagInput" />
+        <input v-model="tag" type="text" :class="slotProps.class" @keydown.enter="add" @blur="v.$touch()" />
       </div>
     </div>
   </InputWrapper>

--- a/frontend/src/components/ui/InputTag.vue
+++ b/frontend/src/components/ui/InputTag.vue
@@ -105,6 +105,13 @@ const filteredOptions = computed(() => {
   }
   return props.options;
 });
+
+const tagInput = (event: Event) => {
+  const target = event.target as HTMLInputElement;
+  if (target.value.trim().length < props.tagMaxlength) {
+    tag.value = target.value;
+  }
+};
 </script>
 
 <template>
@@ -129,14 +136,14 @@ const filteredOptions = computed(() => {
       </span>
       <template v-if="options">
         <input
-          v-model="tag"
+          :value="tag"
           type="text"
           v-bind="$attrs"
           :class="slotProps.class"
           :list="id"
-          :maxlength="tagMaxlength"
           class="pointer-events-auto flex-grow !bg-gray-100 rounded-xl px-2 dark:(!bg-gray-500 text-white)"
           @blur="v.$touch()"
+          @input="tagInput"
           @keydown.enter="add"
           @change="add"
         />
@@ -152,7 +159,7 @@ const filteredOptions = computed(() => {
         :class="slotProps.class"
       >
         <IconMdiSubdirectoryArrowLeft class="absolute right-2"> </IconMdiSubdirectoryArrowLeft>
-        <input v-model="tag" type="text" :class="slotProps.class" :maxlength="tagMaxlength" @keydown.enter="add" @blur="v.$touch()" />
+        <input :value="tag" type="text" :class="slotProps.class" @keydown.enter="add" @blur="v.$touch()" @input="tagInput" />
       </div>
     </div>
   </InputWrapper>

--- a/frontend/src/pages/[user]/[project]/settings/[...slug].vue
+++ b/frontend/src/pages/[user]/[project]/settings/[...slug].vue
@@ -280,7 +280,7 @@ useHead(useSeo(i18n.t("project.settings.title") + " | " + props.project.name, pr
               v-model="form.settings.keywords"
               counter
               :maxlength="useBackendData.validations?.project?.keywords?.max || 5"
-              :tag-maxlength="useBackendData.validations?.project?.keywordName?.max"
+              :tag-maxlength="useBackendData.validations?.project?.keywordName?.max || 16"
               :label="i18n.t('project.new.step3.keywords')"
               :rules="[maxLength()(useBackendData.validations?.project?.keywords?.max || 5), noDuplicated()(() => form.settings.keywords)]"
             />

--- a/frontend/src/pages/new.vue
+++ b/frontend/src/pages/new.vue
@@ -267,6 +267,7 @@ function createProject() {
           <InputTag
             v-model="form.settings.keywords"
             :label="i18n.t('project.new.step3.keywords')"
+            :tag-maxlength="useBackendData.validations?.project?.keywordName?.max"
             :rules="[maxLength()(useBackendData?.validations?.project?.keywords?.max || 5), noDuplicated()(() => form.settings.keywords)]"
             :maxlength="useBackendData?.validations?.project?.keywords?.max || 5"
             counter

--- a/frontend/src/pages/new.vue
+++ b/frontend/src/pages/new.vue
@@ -267,7 +267,7 @@ function createProject() {
           <InputTag
             v-model="form.settings.keywords"
             :label="i18n.t('project.new.step3.keywords')"
-            :tag-maxlength="useBackendData.validations?.project?.keywordName?.max"
+            :tag-maxlength="useBackendData.validations?.project?.keywordName?.max || 16"
             :rules="[maxLength()(useBackendData?.validations?.project?.keywords?.max || 5), noDuplicated()(() => form.settings.keywords)]"
             :maxlength="useBackendData?.validations?.project?.keywords?.max || 5"
             counter

--- a/frontend/src/pages/tools/importer.vue
+++ b/frontend/src/pages/tools/importer.vue
@@ -338,6 +338,7 @@ useHead(useSeo(t("importer.title"), null, route, null));
                     <InputTag
                       v-model="project.settings.keywords"
                       :label="t('project.new.step3.keywords')"
+                      :tag-maxlength="useBackendData.validations?.project?.keywordName?.max"
                       :rules="[maxLength()(useBackendData?.validations?.project?.keywords?.max || 5), noDuplicated()(() => project.settings.keywords)]"
                       :maxlength="useBackendData?.validations?.project?.keywords?.max || 5"
                       counter

--- a/frontend/src/pages/tools/importer.vue
+++ b/frontend/src/pages/tools/importer.vue
@@ -338,7 +338,7 @@ useHead(useSeo(t("importer.title"), null, route, null));
                     <InputTag
                       v-model="project.settings.keywords"
                       :label="t('project.new.step3.keywords')"
-                      :tag-maxlength="useBackendData.validations?.project?.keywordName?.max"
+                      :tag-maxlength="useBackendData.validations?.project?.keywordName?.max || 16"
                       :rules="[maxLength()(useBackendData?.validations?.project?.keywords?.max || 5), noDuplicated()(() => project.settings.keywords)]"
                       :maxlength="useBackendData?.validations?.project?.keywords?.max || 5"
                       counter


### PR DESCRIPTION
This fixes #1183. 

Due to the way the maxLength on the input type works, if we are at the 15 character limit for a keyword it will not allow us to add a space. By handling the max length ourselves, we're able to more specifically allow spaces / commas once we've hit the maxLength. This also means not using the v-model approach to gain more customisability. 

There were also places where the tag-maxlength were not added to the Input element, causing projects to have tags that are longer than 15 characters.