### PR TITLE
Fix inconsistent text when locking organisations

### DIFF
--- a/frontend/src/i18n/locales/en.json
+++ b/frontend/src/i18n/locales/en.json
@@ -785,13 +785,25 @@
       "activity": "User Activity",
       "admin": "User Admin",
       "transfer": "Transfer organization to another user",
-      "delete": "Delete organization"
+      "delete": "Delete organization",
+      "lockOrg": "Lock organization",
+      "unlockOrg": "Unlock organization"
     },
     "lock": {
       "confirmLock": "Lock {0}'s account?",
       "confirmUnlock": "Unlock {0}'s account?",
       "successLock": "Successfully locked {0}'s account",
-      "successUnlock": "Successfully unlocked {0}'s account"
+      "successUnlock": "Successfully unlocked {0}'s account",
+      "confirmLockOrg": "Lock the {0} organization?",
+      "confirmUnlockOrg": "Unlock the {0} organization?",
+      "successLockOrg": "Successfully locked the {0} organization",
+      "successUnlockOrg": "Successfully unlocked the {0} organization",
+      "deleteProjects": "Delete ALL projects of user",
+      "reinstateProjects": "Reinstate ALL deleted projects of user",
+      "deleteProjectsOrg": "Delete ALL projects of the organization",
+      "reinstateProjectsOrg": "Reinstate ALL deleted projects of the organization",
+      "reasonLock": "Reason for locking",
+      "reasonUnlock": "Reason for unlocking"
     },
     "org": {
       "editAvatar": "Edit avatar"


### PR DESCRIPTION
Fixes #1191. 

Whilst this UI is only visible to Hangar staff it makes sense to fix this stuff anyway. 

* I've added proper validation to the comment / reason box when locking and unlocking both users & organisations. 
* It will now say Organisation instead of User when locking / unlocking organisations
* Turn reinstate or delete project strings into translatable i18n strings.

