### PR TITLE
Add devcontainers configuration

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,42 @@
+{
+	"name": "Hangar",
+	"image": "mcr.microsoft.com/devcontainers/java:0-17",
+	"features": {
+		"ghcr.io/devcontainers/features/java:1": {
+			"version": "none",
+			"installMaven": "true",
+			"installGradle": "false"
+		},
+		"ghcr.io/devcontainers/features/docker-in-docker:2": {},
+		"ghcr.io/devcontainers-contrib/features/pnpm:2": {}
+	},
+	"portsAttributes": {
+		"1025": {
+			"label": "MailSlurper SMTP"
+		},
+		"3333": {
+			"label": "Hangar Frontend"
+		},
+		"4436-4437": {
+			"label": "MailSlurper HTTP"
+		},
+		"5432": {
+			"label": "Postgres"
+		},
+		"8080": {
+			"label": "Hangar Backend"
+		}
+	},
+	"remoteEnv": {
+		"BACKEND_HOST": "https://localhost:8080",
+		"BACKEND_DATA_HOST": "https://localhost:8080"
+	},
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"vscjava.vscode-java-pack",
+				"Vue.volar"
+			]
+		}
+	}
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,9 +3,8 @@
 	"image": "mcr.microsoft.com/devcontainers/java:0-17",
 	"features": {
 		"ghcr.io/devcontainers/features/java:1": {
-			"version": "none",
-			"installMaven": "true",
-			"installGradle": "false"
+			"version": "none", // Java is already present.
+			"installMaven": "true"
 		},
 		"ghcr.io/devcontainers/features/docker-in-docker:2": {},
 		"ghcr.io/devcontainers-contrib/features/pnpm:2": {}
@@ -15,7 +14,7 @@
 			"label": "MailSlurper SMTP"
 		},
 		"3333": {
-			"label": "Hangar Frontend"
+			"label": "Nuxt Frontend"
 		},
 		"4436-4437": {
 			"label": "MailSlurper HTTP"
@@ -24,9 +23,13 @@
 			"label": "Postgres"
 		},
 		"8080": {
-			"label": "Hangar Backend"
+			"label": "Maven Backend"
+		},
+		"9411": {
+			"label": "Zipkin"
 		}
 	},
+	"postCreateCommand": "bash ./.devcontainer/post-create.sh",
 	"remoteEnv": {
 		"BACKEND_HOST": "https://localhost:8080",
 		"BACKEND_DATA_HOST": "https://localhost:8080"

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,10 +1,10 @@
 ## Sets up an bare-bones Hangar environment to make developing in Codespaces quicker and easier.
 
 ## Install Maven dependencies (backend)
-cd backend && mvn dependency:go-offline
+cd backend && mvn dependency:go-offline -q
 
 ## Install PNPM dependencies (frontend)
-cd ../frontend && pnpm i
+cd ../frontend && pnpm i --silent
 
 ## Create Docker containers (db & email)
-cd ../docker && docker-compose -f dev.yml up --no-start
+cd ../docker && docker-compose -f dev.yml up --no-start --quiet-pull

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,0 +1,10 @@
+## Sets up an bare-bones Hangar environment to make developing in Codespaces quicker and easier.
+
+## Install Maven dependencies (backend)
+cd backend && mvn dependency:go-offline
+
+## Install PNPM dependencies (frontend)
+cd ../frontend && pnpm i
+
+## Create Docker containers (db & email)
+cd ../docker && docker-compose -f dev.yml up --no-start


### PR DESCRIPTION
Allows the quick creation of GitHub Codespaces & others that support devcontainers by adding an `.devcontainers/devcontainer.json` file containing port labelling, VSCode extensions, and the required features to get an bare-bones Hangar application working (database and email Docker containers, Maven dependencies for the backend application and PNPM dependencies for the frontend), which are setup by an `post-create.sh` Shell script. This allows developers to get coding faster, rather than spend time setting up their development environments.