### PR TITLE
Fix the version page not loading when visiting directly.

### DIFF
--- a/frontend/src/pages/[user]/[project].vue
+++ b/frontend/src/pages/[user]/[project].vue
@@ -44,7 +44,7 @@ provide("updateProjectPages", function (pages: HangarProjectPage[]) {
 </script>
 
 <template>
-  <div v-if="project && user">
+  <div v-if="project">
     <ProjectHeader :project="project" />
     <ProjectNav :project="project" />
     <router-view v-slot="{ Component }">

--- a/frontend/src/pages/[user]/[project]/versions/[version]/index.vue
+++ b/frontend/src/pages/[user]/[project]/versions/[version]/index.vue
@@ -40,7 +40,7 @@ const props = defineProps<{
   version: HangarVersion;
   project: HangarProject;
   versionPlatforms: Set<Platform>;
-  user: User;
+  user?: User;
 }>();
 
 const projectVersion = computed<HangarVersion | undefined>(() => props.version);
@@ -286,28 +286,30 @@ async function restoreVersion() {
         </template>
 
         <table class="w-full">
-          <tr>
-            <th class="text-left">{{ i18n.t("project.info.publishDate") }}</th>
-            <td class="text-right">{{ i18n.d(version.createdAt, "date") }}</td>
-          </tr>
-          <tr>
-            <th class="text-left">
-              {{ i18n.t(hasPerms(NamedPermission.IS_SUBJECT_MEMBER) ? "project.info.totalTotalDownloads" : "project.info.totalDownloads", 0) }}
-            </th>
-            <td class="text-right">
-              {{ version.stats.totalDownloads.toLocaleString("en-US") }}
-            </td>
-          </tr>
-          <!-- Only show per platform downloads to project members, otherwise not too relevant and only adding to height -->
-          <tr v-for="platform in hasPerms(NamedPermission.IS_SUBJECT_MEMBER) ? Object.keys(version.stats.platformDownloads) : []" :key="platform">
-            <th class="text-left inline-flex">
-              <PlatformLogo :platform="platform" :size="24" class="mr-1" />
-              {{ i18n.t("project.info.totalDownloads", 0) }}
-            </th>
-            <td class="text-right">
-              {{ version.stats.platformDownloads[platform].toLocaleString("en-US") }}
-            </td>
-          </tr>
+          <tbody>
+            <tr>
+              <th class="text-left">{{ i18n.t("project.info.publishDate") }}</th>
+              <td class="text-right">{{ i18n.d(version.createdAt, "date") }}</td>
+            </tr>
+            <tr>
+              <th class="text-left">
+                {{ i18n.t(hasPerms(NamedPermission.IS_SUBJECT_MEMBER) ? "project.info.totalTotalDownloads" : "project.info.totalDownloads", 0) }}
+              </th>
+              <td class="text-right">
+                {{ version.stats.totalDownloads.toLocaleString("en-US") }}
+              </td>
+            </tr>
+            <!-- Only show per platform downloads to project members, otherwise not too relevant and only adding to height -->
+            <tr v-for="platform in hasPerms(NamedPermission.IS_SUBJECT_MEMBER) ? Object.keys(version.stats.platformDownloads) : []" :key="platform">
+              <th class="text-left inline-flex">
+                <PlatformLogo :platform="platform" :size="24" class="mr-1" />
+                {{ i18n.t("project.info.totalDownloads", 0) }}
+              </th>
+              <td class="text-right">
+                {{ version.stats.platformDownloads[platform].toLocaleString("en-US") }}
+              </td>
+            </tr>
+          </tbody>
         </table>
       </Card>
 


### PR DESCRIPTION
This fixes #1214 

When visiting a version page directly it would not load properly. The server was no longer rendering the page due to the user call being non-blocking, this PR changes it so that the server now properly renders the page prior to the client allowing for proper hydration to occur.

The changes to the table are due to another hydration mis-match where the browser automatically adds a `<tbody>` tag inside the table, which then causes the client to think there is a mis-match as it did not exist originally. 