### PR TITLE
Don't allow an empty files list

### DIFF
--- a/backend/src/main/java/io/papermc/hangar/model/internal/versions/VersionUpload.java
+++ b/backend/src/main/java/io/papermc/hangar/model/internal/versions/VersionUpload.java
@@ -3,6 +3,7 @@ package io.papermc.hangar.model.internal.versions;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.Size;
 import java.util.*;
 import io.papermc.hangar.controller.validations.Validate;
@@ -22,6 +23,7 @@ public class VersionUpload {
     // @el(root: String)
     private final @Validate(SpEL = "@validate.max(#root, @hangarConfig.pages.maxLen)", message = "page.new.error.maxLength") String description;
     @Size(min = 1, max = 3, message = "version.new.error.invalidNumOfPlatforms")
+    @NotEmpty(message = "version.new.error.invalidNumOfPlatforms")
     private final List<@Valid MultipartFileOrUrl> files;
 
     // @el(root: String)


### PR DESCRIPTION
Fixes #1222 

The size check here is likely not working because the list is null, now we tell the user that the data they have submitted is invalid.