### PR TITLE
Squash some version queries

### DIFF
--- a/backend/src/main/java/io/papermc/hangar/db/dao/internal/table/versions/downloads/ProjectVersionDownloadsDAO.java
+++ b/backend/src/main/java/io/papermc/hangar/db/dao/internal/table/versions/downloads/ProjectVersionDownloadsDAO.java
@@ -5,6 +5,7 @@ import io.papermc.hangar.model.db.versions.downloads.ProjectVersionDownloadTable
 import io.papermc.hangar.model.db.versions.downloads.ProjectVersionPlatformDownloadTable;
 import java.util.Collection;
 import java.util.List;
+import org.apache.commons.lang3.tuple.Pair;
 import org.jdbi.v3.core.enums.EnumByOrdinal;
 import org.jdbi.v3.sqlobject.config.RegisterConstructorMapper;
 import org.jdbi.v3.sqlobject.customizer.BindBean;
@@ -37,6 +38,11 @@ public interface ProjectVersionDownloadsDAO {
 
     @SqlQuery("SELECT * FROM project_version_platform_downloads WHERE version_id = :versionId")
     List<ProjectVersionPlatformDownloadTable> getPlatformDownloads(long versionId);
+
+    @SqlQuery("SELECT pvpd.*, pvd.file_size, pvd.hash, pvd.file_name, pvd.external_url FROM project_version_platform_downloads pvpd " +
+        "JOIN project_version_downloads pvd ON pvd.id = pvpd.download_id " +
+        "WHERE pvpd.version_id = :versionId")
+    List<Pair<ProjectVersionPlatformDownloadTable, ProjectVersionDownloadTable>> getPlatformDownloadsFull(long versionId);
 
     @SqlQuery("SELECT * FROM project_version_platform_downloads WHERE version_id = :versionId AND download_id = :downloadId")
     List<ProjectVersionPlatformDownloadTable> getPlatformDownloads(long versionId, long downloadId);

--- a/backend/src/main/java/io/papermc/hangar/db/dao/v1/VersionsApiDAO.java
+++ b/backend/src/main/java/io/papermc/hangar/db/dao/v1/VersionsApiDAO.java
@@ -186,6 +186,19 @@ public interface VersionsApiDAO {
     @RegisterConstructorMapper(PluginDependency.class)
     Set<PluginDependency> getPluginDependencies(long versionId, @EnumByOrdinal Platform platform); // TODO make into one db call for all platforms?
 
+    @SqlQuery("SELECT " +
+        "       pvd.name," +
+        "       pvd.required," +
+        "       pvd.external_url," +
+        "       p.owner_name pn_owner," +
+        "       p.slug pn_slug," +
+        "       pvd.platform" +
+        "   FROM project_version_dependencies pvd" +
+        "       LEFT JOIN projects p ON pvd.project_id = p.id" +
+        "   WHERE pvd.version_id = :versionId")
+    @RegisterConstructorMapper(PluginDependency.class)
+    Set<PluginDependency> getPluginDependencies(long versionId);
+
     @KeyColumn("platform")
     @ValueColumn("versions")
     @SqlQuery("SELECT" +

--- a/backend/src/main/java/io/papermc/hangar/model/api/project/version/PluginDependency.java
+++ b/backend/src/main/java/io/papermc/hangar/model/api/project/version/PluginDependency.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import io.papermc.hangar.controller.validations.AtLeastOneNotNull;
 import io.papermc.hangar.model.Named;
 import io.papermc.hangar.model.api.project.ProjectNamespace;
+import io.papermc.hangar.model.common.Platform;
 import java.util.Objects;
 import org.jdbi.v3.core.mapper.Nested;
 import org.jdbi.v3.core.mapper.reflect.JdbiConstructor;
@@ -17,21 +18,24 @@ public class PluginDependency implements Named {
     private final boolean required;
     private final ProjectNamespace namespace;
     private final String externalUrl;
+    private final Platform platform;
 
     @JdbiConstructor
     @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
-    public PluginDependency(final @Nullable String name, final boolean required, @Nested("pn") final @Nullable ProjectNamespace namespace, final String externalUrl) {
+    public PluginDependency(final @Nullable String name, final boolean required, @Nested("pn") final @Nullable ProjectNamespace namespace, final String externalUrl, final Platform platform) {
         this.name = namespace != null ? null : name;
         this.required = required;
         this.namespace = namespace;
         this.externalUrl = externalUrl;
+        this.platform = platform;
     }
 
-    private PluginDependency(final String name, final boolean required) {
+    private PluginDependency(final String name, final boolean required, final Platform platform) {
         this.name = name;
         this.required = required;
         this.namespace = null;
         this.externalUrl = null;
+        this.platform = platform;
     }
 
     @Override
@@ -50,6 +54,8 @@ public class PluginDependency implements Named {
     public String getExternalUrl() {
         return this.externalUrl;
     }
+
+    public Platform getPlatform(){ return this.platform; }
 
     @Override
     public String toString() {
@@ -74,7 +80,7 @@ public class PluginDependency implements Named {
         return Objects.hash(this.name, this.required, this.namespace, this.externalUrl);
     }
 
-    public static PluginDependency of(final String name, final boolean required) {
-        return new PluginDependency(name, required);
+    public static PluginDependency of(final String name, final boolean required, final Platform platform) {
+        return new PluginDependency(name, required, platform);
     }
 }

--- a/backend/src/main/java/io/papermc/hangar/service/internal/versions/VersionDependencyService.java
+++ b/backend/src/main/java/io/papermc/hangar/service/internal/versions/VersionDependencyService.java
@@ -69,13 +69,8 @@ public class VersionDependencyService extends HangarComponent {
             platformDependenciesFormatted.put(entry.getKey(), formattedVersionRange);
         });
 
-        final Map<Platform, Set<PluginDependency>> pluginDependencies = new EnumMap<>(Platform.class);
-        Arrays.stream(Platform.getValues()).parallel().forEach(platform -> {
-            final Set<PluginDependency> pluginDependencySet = this.versionsApiDAO.getPluginDependencies(versionId, platform);
-            if (!pluginDependencySet.isEmpty()) {
-                pluginDependencies.put(platform, pluginDependencySet);
-            }
-        });
+        final Map<Platform, Set<PluginDependency>> pluginDependencies = this.versionsApiDAO.getPluginDependencies(versionId).stream()
+            .collect(Collectors.groupingBy(PluginDependency::getPlatform, Collectors.toSet()));
 
         final Map<Platform, PlatformVersionDownload> downloads = this.downloadService.getDownloads(user, project, versionName, versionId);
         return new DownloadsAndDependencies(pluginDependencies, platformDependencies, platformDependenciesFormatted, downloads);

--- a/backend/src/main/java/io/papermc/hangar/service/internal/versions/plugindata/handler/PaperFileTypeHandler.java
+++ b/backend/src/main/java/io/papermc/hangar/service/internal/versions/plugindata/handler/PaperFileTypeHandler.java
@@ -53,12 +53,12 @@ public class PaperFileTypeHandler extends FileTypeHandler<PaperFileData> {
             final Set<PluginDependency> dependencies = new HashSet<>();
             if (this.hardDepends != null) {
                 for (final String hardDepend : this.hardDepends) {
-                    dependencies.add(PluginDependency.of(hardDepend, true));
+                    dependencies.add(PluginDependency.of(hardDepend, true, Platform.PAPER));
                 }
             }
             if (this.softDepends != null) {
                 for (final String softDepend : this.softDepends) {
-                    dependencies.add(PluginDependency.of(softDepend, false));
+                    dependencies.add(PluginDependency.of(softDepend, false, Platform.PAPER));
                 }
             }
             return dependencies;

--- a/backend/src/main/java/io/papermc/hangar/service/internal/versions/plugindata/handler/VelocityFileTypeHandler.java
+++ b/backend/src/main/java/io/papermc/hangar/service/internal/versions/plugindata/handler/VelocityFileTypeHandler.java
@@ -32,7 +32,7 @@ public class VelocityFileTypeHandler extends FileTypeHandler<VelocityFileData> {
 
         @Override
         protected @NotNull Set<PluginDependency> createPluginDependencies() {
-            return this.dependencies.stream().map(dependency -> PluginDependency.of(dependency.id, !dependency.optional)).collect(Collectors.toSet());
+            return this.dependencies.stream().map(dependency -> PluginDependency.of(dependency.id, !dependency.optional, Platform.VELOCITY)).collect(Collectors.toSet());
         }
 
         @ConfigSerializable

--- a/backend/src/main/java/io/papermc/hangar/service/internal/versions/plugindata/handler/WaterfallFileTypeHandler.java
+++ b/backend/src/main/java/io/papermc/hangar/service/internal/versions/plugindata/handler/WaterfallFileTypeHandler.java
@@ -40,12 +40,12 @@ public class WaterfallFileTypeHandler extends FileTypeHandler<WaterfallFileData>
             final Set<PluginDependency> dependencies = new HashSet<>();
             if (this.hardDepends != null) {
                 for (final String hardDepend : this.hardDepends) {
-                    dependencies.add(PluginDependency.of(hardDepend, true));
+                    dependencies.add(PluginDependency.of(hardDepend, true, Platform.WATERFALL));
                 }
             }
             if (this.softDepends != null) {
                 for (final String softDepend : this.softDepends) {
-                    dependencies.add(PluginDependency.of(softDepend, false));
+                    dependencies.add(PluginDependency.of(softDepend, false, Platform.WATERFALL));
                 }
             }
             return dependencies;


### PR DESCRIPTION
A few small changes that squash a few queries to improve performance. 

Firstly the getDownloads call by joining the two tables we're able to remove the prior query to grab all of the downloads for this version. 

Secondly, by adding the platform into the PluginDependency class we can remove the need to query for the plugin dependencies of each platform individually. 

Hopefully will produce some small savings on requests.