### PR TITLE
Add missing platform in query and add nullable as a safety

### DIFF
--- a/backend/src/main/java/io/papermc/hangar/db/dao/v1/VersionsApiDAO.java
+++ b/backend/src/main/java/io/papermc/hangar/db/dao/v1/VersionsApiDAO.java
@@ -178,6 +178,7 @@ public interface VersionsApiDAO {
         "       pvd.name," +
         "       pvd.required," +
         "       pvd.external_url," +
+        "       pvd.platform," +
         "       p.owner_name pn_owner," +
         "       p.slug pn_slug" +
         "   FROM project_version_dependencies pvd" +

--- a/backend/src/main/java/io/papermc/hangar/model/api/project/version/PluginDependency.java
+++ b/backend/src/main/java/io/papermc/hangar/model/api/project/version/PluginDependency.java
@@ -22,7 +22,7 @@ public class PluginDependency implements Named {
 
     @JdbiConstructor
     @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)
-    public PluginDependency(final @Nullable String name, final boolean required, @Nested("pn") final @Nullable ProjectNamespace namespace, final String externalUrl, final Platform platform) {
+    public PluginDependency(final @Nullable String name, final boolean required, @Nested("pn") final @Nullable ProjectNamespace namespace, final String externalUrl, final @Nullable Platform platform) {
         this.name = namespace != null ? null : name;
         this.required = required;
         this.namespace = namespace;
@@ -55,7 +55,7 @@ public class PluginDependency implements Named {
         return this.externalUrl;
     }
 
-    public Platform getPlatform(){ return this.platform; }
+    public @Nullable Platform getPlatform(){ return this.platform; }
 
     @Override
     public String toString() {


### PR DESCRIPTION
I missed the platform in the pre-existing query previously which is causing issues when mapping. This adds the platform field to the column and marks it as nullable.