### PR TITLE
feat: implement basic oauth2 features, closes #1136

### DIFF
--- a/.run/frontend.run.xml
+++ b/.run/frontend.run.xml
@@ -6,9 +6,7 @@
       <script value="dev" />
     </scripts>
     <node-interpreter value="project" />
-    <envs>
-      <env name="DEBUG" value="hangar:*" />
-    </envs>
+    <envs />
     <method v="2" />
   </configuration>
 </component>

--- a/backend/src/main/java/io/papermc/hangar/components/auth/config/JWTConfig.java
+++ b/backend/src/main/java/io/papermc/hangar/components/auth/config/JWTConfig.java
@@ -22,4 +22,9 @@ public class JWTConfig extends HangarComponent {
     public Algorithm algorithm() {
         return Algorithm.HMAC256(this.config.security.tokenSecret());
     }
+
+    @Bean
+    public JWT jwt() {
+        return new JWT();
+    }
 }

--- a/backend/src/main/java/io/papermc/hangar/components/auth/controller/AuthController.java
+++ b/backend/src/main/java/io/papermc/hangar/components/auth/controller/AuthController.java
@@ -117,7 +117,7 @@ public class AuthController extends HangarComponent {
         }
 
         final boolean hasTotp = this.credentialsService.getCredential(userId, CredentialType.TOTP) != null;
-        final boolean hasPassword = this.credentialsService.getCredential(userId, CredentialType.TOTP) != null;
+        final boolean hasPassword = this.credentialsService.getCredential(userId, CredentialType.PASSWORD) != null;
         final boolean emailVerified = Objects.requireNonNull(this.userService.getUserTable(userId)).isEmailVerified();
 
         final VerificationCodeTable verificationCode = this.verificationService.getVerificationCode(userId, VerificationCodeTable.VerificationCodeType.EMAIL_VERIFICATION);
@@ -146,7 +146,7 @@ public class AuthController extends HangarComponent {
     @PostMapping("/account")
     public void saveAccount(@RequestBody final AccountForm form) {
         final long userId = this.getHangarPrincipal().getUserId();
-        final boolean hasPassword = this.credentialsService.getCredential(userId, CredentialType.TOTP) != null;
+        final boolean hasPassword = this.credentialsService.getCredential(userId, CredentialType.PASSWORD) != null;
         if (hasPassword) {
             this.credentialsService.verifyPassword(userId, form.currentPassword());
         }

--- a/backend/src/main/java/io/papermc/hangar/components/auth/controller/CredentialController.java
+++ b/backend/src/main/java/io/papermc/hangar/components/auth/controller/CredentialController.java
@@ -363,7 +363,11 @@ public class CredentialController extends HangarComponent {
         final UserTable userTable = this.userService.getUserTable(form.email());
         if (userTable != null) {
             if (this.authService.validPassword(form.password(), userTable.getName()) && this.verificationService.verifyResetCode(form.email(), form.code(), true)) {
-                this.credentialsService.updateCredential(userTable.getUserId(), new PasswordCredential(this.passwordEncoder.encode(form.password())));
+                final PasswordCredential credential = new PasswordCredential(this.passwordEncoder.encode(form.password()));
+                final boolean success = this.credentialsService.updateCredential(userTable.getUserId(), credential);
+                if (!success) {
+                    this.credentialsService.registerCredential(userTable.getUserId(), credential);
+                }
                 return ResponseEntity.ok().build();
             }
         }

--- a/backend/src/main/java/io/papermc/hangar/components/auth/controller/OAuthController.java
+++ b/backend/src/main/java/io/papermc/hangar/components/auth/controller/OAuthController.java
@@ -1,0 +1,112 @@
+package io.papermc.hangar.components.auth.controller;
+
+import com.auth0.jwt.interfaces.DecodedJWT;
+import io.papermc.hangar.HangarComponent;
+import io.papermc.hangar.components.auth.model.credential.OAuthCredential;
+import io.papermc.hangar.components.auth.model.oauth.OAuthMode;
+import io.papermc.hangar.components.auth.model.oauth.OAuthUserDetails;
+import io.papermc.hangar.components.auth.service.AuthService;
+import io.papermc.hangar.components.auth.service.CredentialsService;
+import io.papermc.hangar.components.auth.service.OAuthService;
+import io.papermc.hangar.components.auth.service.TokenService;
+import io.papermc.hangar.model.db.UserTable;
+import io.papermc.hangar.security.annotations.aal.RequireAal;
+import io.papermc.hangar.security.annotations.ratelimit.RateLimit;
+import java.io.IOException;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+@Controller
+@RateLimit(path = "auth")
+@RequestMapping(path = "/api/internal/oauth", produces = MediaType.APPLICATION_JSON_VALUE)
+@ResponseBody
+public class OAuthController extends HangarComponent {
+
+    private final OAuthService oAuthService;
+    private final TokenService tokenService;
+    private final AuthService authService;
+    private final CredentialsService credentialsService;
+
+    public OAuthController(final OAuthService oAuthService, final TokenService tokenService, final AuthService authService, final CredentialsService credentialsService) {
+        this.oAuthService = oAuthService;
+        this.tokenService = tokenService;
+        this.authService = authService;
+        this.credentialsService = credentialsService;
+    }
+
+    @GetMapping("/{provider}/login")
+    public String login(@PathVariable final String provider, @RequestParam final OAuthMode mode, @RequestParam(required = false) final String returnUrl) throws IOException {
+        // TODO sanitize return url
+        final String state = this.oAuthService.oauthState(this.getHangarUserId(), mode, returnUrl);
+        final String loginUrl = this.oAuthService.getLoginUrl(provider, state);
+        if (mode == OAuthMode.SETTINGS) {
+            return loginUrl;
+        } else {
+            this.redirect(loginUrl);
+            return null;
+        }
+    }
+
+    @GetMapping("/{provider}/callback")
+    public void callback(@PathVariable final String provider, @RequestParam(required = false) final String code, @RequestParam final String state) throws IOException {
+        final DecodedJWT decodedState = this.tokenService.verify(state);
+        final OAuthMode mode = decodedState.getClaim("mode").as(OAuthMode.class);
+        final String returnUrl = decodedState.getClaim("returnUrl").asString();
+
+        if (code != null) {
+            final String token = this.oAuthService.redeemCode(provider, code);
+            if (token != null) {
+                final OAuthUserDetails userDetails = this.oAuthService.getUserDetails(provider, token);
+
+                switch (mode) {
+                    case LOGIN, SIGNUP -> {
+                        final UserTable existingUser = this.oAuthService.login(provider, userDetails.id(), userDetails.username());
+                        if (existingUser != null) {
+                            this.authService.setAalAndLogin(existingUser, 2);
+                            this.redirect(returnUrl);
+                        }
+
+                        // TODO show tos and allow to change username and email somehow
+                        final String email = userDetails.email();
+                        final String username = userDetails.username();
+                        final boolean tos = true;
+
+                        final UserTable newUser = this.oAuthService.register(provider, userDetails.id(), username, email, tos, userDetails.email().equals(email));
+                        this.credentialsService.registerCredential(newUser.getUserId(), new OAuthCredential(provider, userDetails.id(), userDetails.username()));
+                        this.authService.setAalAndLogin(newUser, 2);
+                        this.redirect(returnUrl);
+                    }
+                    case SETTINGS -> {
+                        final long userId = Long.parseLong(decodedState.getSubject());
+                        this.credentialsService.registerCredential(userId, new OAuthCredential(provider, userDetails.id(), userDetails.username()));
+                        this.redirect(returnUrl);
+                    }
+                }
+            }
+        } else {
+            this.redirect(returnUrl);
+        }
+    }
+
+    @RequireAal(2)
+    @PostMapping("/{provider}/unlink/{id}")
+    public String unlink(@PathVariable final String provider, @PathVariable final String id) {
+        return this.oAuthService.unlink(provider, id);
+    }
+
+    private void redirect(String returnUrl) throws IOException {
+        if (returnUrl == null) {
+            returnUrl = "/";
+        }
+        if (this.config.isDev() && !returnUrl.startsWith("http")) {
+            returnUrl = "http://localhost:3333" + returnUrl;
+        }
+        this.response.sendRedirect(returnUrl);
+    }
+}

--- a/backend/src/main/java/io/papermc/hangar/components/auth/controller/OAuthController.java
+++ b/backend/src/main/java/io/papermc/hangar/components/auth/controller/OAuthController.java
@@ -46,7 +46,10 @@ public class OAuthController extends HangarComponent {
 
     @GetMapping("/{provider}/login")
     public String login(@PathVariable final String provider, @RequestParam final OAuthMode mode, @RequestParam(required = false) final String returnUrl) throws IOException {
-        // TODO sanitize return url
+        if (!returnUrl.startsWith("/") || returnUrl.contains("..")) {
+            throw new HangarApiException("Invalid return url");
+        }
+
         final String state = this.oAuthService.oauthState(this.getHangarUserId(), mode, returnUrl);
         final String loginUrl = this.oAuthService.getLoginUrl(provider, state);
         if (mode == OAuthMode.SETTINGS) {

--- a/backend/src/main/java/io/papermc/hangar/components/auth/controller/OAuthController.java
+++ b/backend/src/main/java/io/papermc/hangar/components/auth/controller/OAuthController.java
@@ -37,13 +37,11 @@ public class OAuthController extends HangarComponent {
     private final OAuthService oAuthService;
     private final TokenService tokenService;
     private final AuthService authService;
-    private final CredentialsService credentialsService;
 
-    public OAuthController(final OAuthService oAuthService, final TokenService tokenService, final AuthService authService, final CredentialsService credentialsService) {
+    public OAuthController(final OAuthService oAuthService, final TokenService tokenService, final AuthService authService) {
         this.oAuthService = oAuthService;
         this.tokenService = tokenService;
         this.authService = authService;
-        this.credentialsService = credentialsService;
     }
 
     @GetMapping("/{provider}/login")
@@ -92,7 +90,7 @@ public class OAuthController extends HangarComponent {
                 }
                 case SETTINGS -> {
                     final long userId = Long.parseLong(decodedState.getSubject());
-                    this.credentialsService.registerCredential(userId, new OAuthCredential(provider, userDetails.id(), userDetails.username()));
+                    this.oAuthService.registerCredentials(provider, userId, userDetails);
                     this.redirect(returnUrl);
                 }
             }
@@ -114,7 +112,7 @@ public class OAuthController extends HangarComponent {
         final boolean tos = form.tos();
 
         final UserTable newUser = this.oAuthService.register(oauthProvider, oauthId, username, email, tos, oauthEmail.equals(email));
-        this.credentialsService.registerCredential(newUser.getUserId(), new OAuthCredential(oauthProvider, oauthId, oauthUsername));
+        this.oAuthService.registerCredentials(oauthProvider, newUser.getUserId(), new OAuthUserDetails(oauthId, oauthUsername, oauthEmail));
         this.authService.setAalAndLogin(newUser, 2);
         return new OAuthSignupResponse(!newUser.isEmailVerified());
     }

--- a/backend/src/main/java/io/papermc/hangar/components/auth/dao/UserCredentialDAO.java
+++ b/backend/src/main/java/io/papermc/hangar/components/auth/dao/UserCredentialDAO.java
@@ -10,9 +10,11 @@ import org.jdbi.v3.core.mapper.JoinRow;
 import org.jdbi.v3.spring5.JdbiRepository;
 import org.jdbi.v3.sqlobject.config.RegisterConstructorMapper;
 import org.jdbi.v3.sqlobject.config.RegisterJoinRowMapper;
+import org.jdbi.v3.sqlobject.customizer.Define;
 import org.jdbi.v3.sqlobject.customizer.Timestamped;
 import org.jdbi.v3.sqlobject.statement.SqlQuery;
 import org.jdbi.v3.sqlobject.statement.SqlUpdate;
+import org.jdbi.v3.stringtemplate4.UseStringTemplateEngine;
 import org.jetbrains.annotations.Nullable;
 
 @JdbiRepository
@@ -26,9 +28,6 @@ public interface UserCredentialDAO {
     @Nullable
     @SqlQuery("SELECT * FROM user_credentials where type = :type and user_id = :userId LIMIT 1")
     UserCredentialTable getByType(@EnumByOrdinal CredentialType type, long userId);
-
-    @SqlQuery("SELECT * FROM user_credentials where type = :type and user_id = :userId")
-    List<UserCredentialTable> getAllByType(@EnumByOrdinal CredentialType type, long userId);
 
     @Nullable
     @SqlQuery("SELECT * FROM user_credentials where type = :type and credential ->> 'user_handle' = :userHandle")
@@ -45,19 +44,21 @@ public interface UserCredentialDAO {
     @SqlQuery("SELECT type FROM user_credentials WHERE user_id = :userId AND type != :password AND (type != :webAuthn OR (credential ->> 'credentials' IS NOT NULL AND jsonb_array_length(credential -> 'credentials') > 0))")
     List<CredentialType> getAll(long userId, @EnumByOrdinal CredentialType password, @EnumByOrdinal CredentialType webAuthn);
 
+    @UseStringTemplateEngine
     @RegisterConstructorMapper(value = UserCredentialTable.class, prefix = "uc")
     @RegisterConstructorMapper(UserTable.class)
     @RegisterJoinRowMapper({UserTable.class, UserCredentialTable.class})
-    @SqlQuery("SELECT u.*, uc.id uc_id, uc.credential uc_credential, uc.created_at uc_created_at, uc.updated_at uc_updated_at, uc.user_id uc_user_id, uc.type uc_type FROM user_credentials uc JOIN users u ON uc.user_id = u.id WHERE credential ->> 'provider' = :provider AND credential ->> 'id' = :id")
-    JoinRow getOAuthUser(String provider, String id);
-
-    @SqlUpdate("DELETE FROM user_credentials WHERE type = :type and user_id = :userId and credential ->> 'provider' = :provider and credential ->> 'id' = :id")
-    void removeOAuth(long userId, @EnumByOrdinal CredentialType type, final String provider, final String id);
-
-    @Timestamped
-    @SqlUpdate("UPDATE user_credentials set credential = :credential, updated_at = :now WHERE type = :type and user_id = :userId and credential ->> 'provider' = :provider and credential ->> 'id' = :id")
-    void updateOAuth(long userId, JSONB credential, @EnumByOrdinal CredentialType type, final String provider, final String id);
-
-    @SqlQuery("SELECT count(*) FROM user_credentials where type = :type and user_id = :userId ")
-    long countByType(long userId, @EnumByOrdinal CredentialType type);
+    @SqlQuery("""
+            SELECT u.*,
+                   uc.id                           uc_id,
+                   uc.credential                   uc_credential,
+                   uc.created_at                   uc_created_at,
+                   uc.updated_at                   uc_updated_at,
+                   uc.user_id                      uc_user_id,
+                   uc.type                         uc_type
+            FROM user_credentials uc
+                JOIN users u ON uc.user_id = u.id
+            WHERE uc.type = :oauth AND jsonb_path_exists(uc.credential, '$.connections[*] ? (@.provider == "<provider>") ? (@.id == "<id>")');
+            """)
+    JoinRow getOAuthUser(@Define String provider, @Define String id, @EnumByOrdinal CredentialType oauth);
 }

--- a/backend/src/main/java/io/papermc/hangar/components/auth/dao/UserCredentialDAO.java
+++ b/backend/src/main/java/io/papermc/hangar/components/auth/dao/UserCredentialDAO.java
@@ -39,7 +39,7 @@ public interface UserCredentialDAO {
 
     @Timestamped
     @SqlUpdate("UPDATE user_credentials set credential = :credential, updated_at = :now WHERE type = :type and user_id = :userId")
-    void update(long userId, JSONB credential, @EnumByOrdinal CredentialType type);
+    boolean update(long userId, JSONB credential, @EnumByOrdinal CredentialType type);
 
     @EnumByOrdinal
     @SqlQuery("SELECT type FROM user_credentials WHERE user_id = :userId AND type != :password AND (type != :webAuthn OR (credential ->> 'credentials' IS NOT NULL AND jsonb_array_length(credential -> 'credentials') > 0))")
@@ -57,4 +57,7 @@ public interface UserCredentialDAO {
     @Timestamped
     @SqlUpdate("UPDATE user_credentials set credential = :credential, updated_at = :now WHERE type = :type and user_id = :userId and credential ->> 'provider' = :provider and credential ->> 'id' = :id")
     void updateOAuth(long userId, JSONB credential, @EnumByOrdinal CredentialType type, final String provider, final String id);
+
+    @SqlQuery("SELECT count(*) FROM user_credentials where type = :type and user_id = :userId ")
+    long countByType(long userId, @EnumByOrdinal CredentialType type);
 }

--- a/backend/src/main/java/io/papermc/hangar/components/auth/dao/UserCredentialDAO.java
+++ b/backend/src/main/java/io/papermc/hangar/components/auth/dao/UserCredentialDAO.java
@@ -3,10 +3,13 @@ package io.papermc.hangar.components.auth.dao;
 import io.papermc.hangar.components.auth.model.credential.CredentialType;
 import io.papermc.hangar.components.auth.model.db.UserCredentialTable;
 import io.papermc.hangar.db.customtypes.JSONB;
+import io.papermc.hangar.model.db.UserTable;
 import java.util.List;
 import org.jdbi.v3.core.enums.EnumByOrdinal;
+import org.jdbi.v3.core.mapper.JoinRow;
 import org.jdbi.v3.spring5.JdbiRepository;
 import org.jdbi.v3.sqlobject.config.RegisterConstructorMapper;
+import org.jdbi.v3.sqlobject.config.RegisterJoinRowMapper;
 import org.jdbi.v3.sqlobject.customizer.Timestamped;
 import org.jdbi.v3.sqlobject.statement.SqlQuery;
 import org.jdbi.v3.sqlobject.statement.SqlUpdate;
@@ -21,8 +24,11 @@ public interface UserCredentialDAO {
     void insert(long userId, JSONB credential, @EnumByOrdinal CredentialType type);
 
     @Nullable
-    @SqlQuery("SELECT * FROM user_credentials where type = :type and user_id = :userId")
+    @SqlQuery("SELECT * FROM user_credentials where type = :type and user_id = :userId LIMIT 1")
     UserCredentialTable getByType(@EnumByOrdinal CredentialType type, long userId);
+
+    @SqlQuery("SELECT * FROM user_credentials where type = :type and user_id = :userId")
+    List<UserCredentialTable> getAllByType(@EnumByOrdinal CredentialType type, long userId);
 
     @Nullable
     @SqlQuery("SELECT * FROM user_credentials where type = :type and credential ->> 'user_handle' = :userHandle")
@@ -38,4 +44,17 @@ public interface UserCredentialDAO {
     @EnumByOrdinal
     @SqlQuery("SELECT type FROM user_credentials WHERE user_id = :userId AND type != :password AND (type != :webAuthn OR (credential ->> 'credentials' IS NOT NULL AND jsonb_array_length(credential -> 'credentials') > 0))")
     List<CredentialType> getAll(long userId, @EnumByOrdinal CredentialType password, @EnumByOrdinal CredentialType webAuthn);
+
+    @RegisterConstructorMapper(value = UserCredentialTable.class, prefix = "uc")
+    @RegisterConstructorMapper(UserTable.class)
+    @RegisterJoinRowMapper({UserTable.class, UserCredentialTable.class})
+    @SqlQuery("SELECT u.*, uc.id uc_id, uc.credential uc_credential, uc.created_at uc_created_at, uc.updated_at uc_updated_at, uc.user_id uc_user_id, uc.type uc_type FROM user_credentials uc JOIN users u ON uc.user_id = u.id WHERE credential ->> 'provider' = :provider AND credential ->> 'id' = :id")
+    JoinRow getOAuthUser(String provider, String id);
+
+    @SqlUpdate("DELETE FROM user_credentials WHERE type = :type and user_id = :userId and credential ->> 'provider' = :provider and credential ->> 'id' = :id")
+    void removeOAuth(long userId, @EnumByOrdinal CredentialType type, final String provider, final String id);
+
+    @Timestamped
+    @SqlUpdate("UPDATE user_credentials set credential = :credential, updated_at = :now WHERE type = :type and user_id = :userId and credential ->> 'provider' = :provider and credential ->> 'id' = :id")
+    void updateOAuth(long userId, JSONB credential, @EnumByOrdinal CredentialType type, final String provider, final String id);
 }

--- a/backend/src/main/java/io/papermc/hangar/components/auth/model/credential/CredentialType.java
+++ b/backend/src/main/java/io/papermc/hangar/components/auth/model/credential/CredentialType.java
@@ -4,5 +4,6 @@ public enum CredentialType {
     PASSWORD,
     BACKUP_CODES,
     TOTP,
-    WEBAUTHN
+    WEBAUTHN,
+    OAUTH
 }

--- a/backend/src/main/java/io/papermc/hangar/components/auth/model/credential/OAuthCredential.java
+++ b/backend/src/main/java/io/papermc/hangar/components/auth/model/credential/OAuthCredential.java
@@ -1,0 +1,9 @@
+package io.papermc.hangar.components.auth.model.credential;
+
+public record OAuthCredential(String provider, String id, String name) implements Credential {
+
+    @Override
+    public CredentialType type() {
+        return CredentialType.OAUTH;
+    }
+}

--- a/backend/src/main/java/io/papermc/hangar/components/auth/model/credential/OAuthCredential.java
+++ b/backend/src/main/java/io/papermc/hangar/components/auth/model/credential/OAuthCredential.java
@@ -1,6 +1,10 @@
 package io.papermc.hangar.components.auth.model.credential;
 
-public record OAuthCredential(String provider, String id, String name) implements Credential {
+import java.util.List;
+
+public record OAuthCredential(List<OAuthConnection> connections) implements Credential {
+
+    public record OAuthConnection(String provider, String id, String name) {}
 
     @Override
     public CredentialType type() {

--- a/backend/src/main/java/io/papermc/hangar/components/auth/model/dto/OAuthSignupForm.java
+++ b/backend/src/main/java/io/papermc/hangar/components/auth/model/dto/OAuthSignupForm.java
@@ -1,0 +1,4 @@
+package io.papermc.hangar.components.auth.model.dto;
+
+public record OAuthSignupForm(String username, String email, String jwt, boolean tos) {
+}

--- a/backend/src/main/java/io/papermc/hangar/components/auth/model/dto/OAuthSignupResponse.java
+++ b/backend/src/main/java/io/papermc/hangar/components/auth/model/dto/OAuthSignupResponse.java
@@ -1,0 +1,4 @@
+package io.papermc.hangar.components.auth.model.dto;
+
+public record OAuthSignupResponse(boolean emailVerificationNeeded) {
+}

--- a/backend/src/main/java/io/papermc/hangar/components/auth/model/dto/SettingsResponse.java
+++ b/backend/src/main/java/io/papermc/hangar/components/auth/model/dto/SettingsResponse.java
@@ -3,7 +3,7 @@ package io.papermc.hangar.components.auth.model.dto;
 import io.papermc.hangar.components.auth.model.credential.OAuthCredential;
 import java.util.List;
 
-public record SettingsResponse(List<Authenticator> authenticators, List<OAuthCredential> oAuthCredentials, boolean hasBackupCodes, boolean hasTotp, boolean emailConfirmed, boolean emailPending) {
+public record SettingsResponse(List<Authenticator> authenticators, List<OAuthCredential> oAuthCredentials, boolean hasBackupCodes, boolean hasTotp, boolean emailConfirmed, boolean emailPending, boolean hasPassword) {
 
     public record Authenticator(String addedAt, String displayName, String id) {}
 }

--- a/backend/src/main/java/io/papermc/hangar/components/auth/model/dto/SettingsResponse.java
+++ b/backend/src/main/java/io/papermc/hangar/components/auth/model/dto/SettingsResponse.java
@@ -1,8 +1,9 @@
 package io.papermc.hangar.components.auth.model.dto;
 
+import io.papermc.hangar.components.auth.model.credential.OAuthCredential;
 import java.util.List;
 
-public record SettingsResponse(List<Authenticator> authenticators, boolean hasBackupCodes, boolean hasTotp, boolean emailConfirmed, boolean emailPending) {
+public record SettingsResponse(List<Authenticator> authenticators, List<OAuthCredential> oAuthCredentials, boolean hasBackupCodes, boolean hasTotp, boolean emailConfirmed, boolean emailPending) {
 
     public record Authenticator(String addedAt, String displayName, String id) {}
 }

--- a/backend/src/main/java/io/papermc/hangar/components/auth/model/dto/SettingsResponse.java
+++ b/backend/src/main/java/io/papermc/hangar/components/auth/model/dto/SettingsResponse.java
@@ -3,7 +3,7 @@ package io.papermc.hangar.components.auth.model.dto;
 import io.papermc.hangar.components.auth.model.credential.OAuthCredential;
 import java.util.List;
 
-public record SettingsResponse(List<Authenticator> authenticators, List<OAuthCredential> oAuthCredentials, boolean hasBackupCodes, boolean hasTotp, boolean emailConfirmed, boolean emailPending, boolean hasPassword) {
+public record SettingsResponse(List<Authenticator> authenticators, List<OAuthCredential.OAuthConnection> oauthConnections, boolean hasBackupCodes, boolean hasTotp, boolean emailConfirmed, boolean emailPending, boolean hasPassword) {
 
     public record Authenticator(String addedAt, String displayName, String id) {}
 }

--- a/backend/src/main/java/io/papermc/hangar/components/auth/model/oauth/OAuthCodeRequest.java
+++ b/backend/src/main/java/io/papermc/hangar/components/auth/model/oauth/OAuthCodeRequest.java
@@ -1,0 +1,6 @@
+package io.papermc.hangar.components.auth.model.oauth;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record OAuthCodeRequest(@JsonProperty("client_id") String clientId, @JsonProperty("client_secret") String clientSecret, String code) {
+}

--- a/backend/src/main/java/io/papermc/hangar/components/auth/model/oauth/OAuthCodeResponse.java
+++ b/backend/src/main/java/io/papermc/hangar/components/auth/model/oauth/OAuthCodeResponse.java
@@ -2,5 +2,5 @@ package io.papermc.hangar.components.auth.model.oauth;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-public record OAuthCodeResponse(@JsonProperty("access_token") String accessToken, String scope) {
+public record OAuthCodeResponse(@JsonProperty("access_token") String accessToken, @JsonProperty("id_token") String idToken, String scope) {
 }

--- a/backend/src/main/java/io/papermc/hangar/components/auth/model/oauth/OAuthCodeResponse.java
+++ b/backend/src/main/java/io/papermc/hangar/components/auth/model/oauth/OAuthCodeResponse.java
@@ -1,0 +1,6 @@
+package io.papermc.hangar.components.auth.model.oauth;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record OAuthCodeResponse(@JsonProperty("access_token") String accessToken, String scope) {
+}

--- a/backend/src/main/java/io/papermc/hangar/components/auth/model/oauth/OAuthMode.java
+++ b/backend/src/main/java/io/papermc/hangar/components/auth/model/oauth/OAuthMode.java
@@ -1,0 +1,5 @@
+package io.papermc.hangar.components.auth.model.oauth;
+
+public enum OAuthMode {
+    LOGIN, SIGNUP, SETTINGS
+}

--- a/backend/src/main/java/io/papermc/hangar/components/auth/model/oauth/OAuthProvider.java
+++ b/backend/src/main/java/io/papermc/hangar/components/auth/model/oauth/OAuthProvider.java
@@ -1,4 +1,97 @@
 package io.papermc.hangar.components.auth.model.oauth;
 
-public record OAuthProvider(String name, String clientId, String clientSecret, String[] scopes) {
+import java.util.Objects;
+
+public final class OAuthProvider {
+
+    public enum Mode {
+        GITHUB,
+        OIDC
+    }
+
+    private final String name;
+    private final String clientId;
+    private final String clientSecret;
+    private final String[] scopes;
+    private final Mode mode;
+    private final String wellKnown;
+
+    private String authorizationEndpoint;
+    private String tokenEndpoint;
+    private String userInfoEndpoint;
+
+    public OAuthProvider(final String name, final String clientId, final String clientSecret, final String[] scopes, final Mode mode, final String wellKnown) {
+        this.name = name;
+        this.clientId = clientId;
+        this.clientSecret = clientSecret;
+        this.scopes = scopes;
+        this.mode = mode;
+        this.wellKnown = wellKnown;
+    }
+
+    public String name() {
+        return this.name;
+    }
+
+    public String clientId() {
+        return this.clientId;
+    }
+
+    public String clientSecret() {
+        return this.clientSecret;
+    }
+
+    public String[] scopes() {
+        return this.scopes;
+    }
+
+    public Mode mode() {
+        return this.mode;
+    }
+
+    public String wellKnown() {
+        return this.wellKnown;
+    }
+
+    public String authorizationEndpoint() {
+        return this.authorizationEndpoint;
+    }
+
+    public void authorizationEndpoint(final String authorizationEndpoint) {
+        this.authorizationEndpoint = authorizationEndpoint;
+    }
+
+    public String tokenEndpoint() {
+        return this.tokenEndpoint;
+    }
+
+    public void tokenEndpoint(final String tokenEndpoint) {
+        this.tokenEndpoint = tokenEndpoint;
+    }
+
+    public String userInfoEndpoint() {
+        return this.userInfoEndpoint;
+    }
+
+    public void userInfoEndpoint(final String userInfoEndpoint) {
+        this.userInfoEndpoint = userInfoEndpoint;
+    }
+
+    @Override
+    public boolean equals(final Object obj) {
+        if (obj == this) return true;
+        if (obj == null || obj.getClass() != this.getClass()) return false;
+        final var that = (OAuthProvider) obj;
+        return Objects.equals(this.name, that.name);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(this.name);
+    }
+
+    @Override
+    public String toString() {
+        return "OAuthProvider[name=" + this.name + ']';
+    }
 }

--- a/backend/src/main/java/io/papermc/hangar/components/auth/model/oauth/OAuthProvider.java
+++ b/backend/src/main/java/io/papermc/hangar/components/auth/model/oauth/OAuthProvider.java
@@ -1,0 +1,4 @@
+package io.papermc.hangar.components.auth.model.oauth;
+
+public record OAuthProvider(String name, String clientId, String clientSecret, String[] scopes) {
+}

--- a/backend/src/main/java/io/papermc/hangar/components/auth/model/oauth/OAuthProvider.java
+++ b/backend/src/main/java/io/papermc/hangar/components/auth/model/oauth/OAuthProvider.java
@@ -1,6 +1,7 @@
 package io.papermc.hangar.components.auth.model.oauth;
 
 import java.util.Objects;
+import org.apache.commons.lang3.StringUtils;
 
 public final class OAuthProvider {
 
@@ -15,18 +16,20 @@ public final class OAuthProvider {
     private final String[] scopes;
     private final Mode mode;
     private final String wellKnown;
+    private final String unlinkLink;
 
     private String authorizationEndpoint;
     private String tokenEndpoint;
     private String userInfoEndpoint;
 
-    public OAuthProvider(final String name, final String clientId, final String clientSecret, final String[] scopes, final Mode mode, final String wellKnown) {
+    public OAuthProvider(final String name, final String clientId, final String clientSecret, final String[] scopes, final Mode mode, final String wellKnown, String unlinkLink) {
         this.name = name;
         this.clientId = clientId;
         this.clientSecret = clientSecret;
         this.scopes = scopes;
         this.mode = mode;
         this.wellKnown = wellKnown;
+        this.unlinkLink = unlinkLink;
     }
 
     public String name() {
@@ -51,6 +54,10 @@ public final class OAuthProvider {
 
     public String wellKnown() {
         return this.wellKnown;
+    }
+
+    public String unlinkLink() {
+        return this.unlinkLink;
     }
 
     public String authorizationEndpoint() {

--- a/backend/src/main/java/io/papermc/hangar/components/auth/model/oauth/OAuthUserDetails.java
+++ b/backend/src/main/java/io/papermc/hangar/components/auth/model/oauth/OAuthUserDetails.java
@@ -1,0 +1,3 @@
+package io.papermc.hangar.components.auth.model.oauth;
+
+public record OAuthUserDetails(String id, String username, String email) {}

--- a/backend/src/main/java/io/papermc/hangar/components/auth/service/AuthService.java
+++ b/backend/src/main/java/io/papermc/hangar/components/auth/service/AuthService.java
@@ -103,14 +103,9 @@ public class AuthService extends HangarComponent implements UserDetailsService {
             throw new HangarApiException("The username and password are too similar");
         }
 
-        try {
-            final int breachAmount = this.hibpService.getBreachAmount(password);
-            if (breachAmount > 10) {
-                throw new HangarApiException("Your password has been found in data breaches, please use a different one");
-            }
-        } catch (final Exception e) {
-            // Don't block account creation if this isn't reachable
-            e.printStackTrace();
+        final int breachAmount = this.hibpService.getBreachAmount(password);
+        if (breachAmount > 10) {
+            throw new HangarApiException("Your password has been found in data breaches, please use a different one");
         }
 
         return true;

--- a/backend/src/main/java/io/papermc/hangar/components/auth/service/CredentialsService.java
+++ b/backend/src/main/java/io/papermc/hangar/components/auth/service/CredentialsService.java
@@ -51,10 +51,6 @@ public class CredentialsService extends HangarComponent {
         return this.userCredentialDAO.getByType(type, userId);
     }
 
-    public List<UserCredentialTable> getAllCredentials(final long userId, final CredentialType type) {
-        return this.userCredentialDAO.getAllByType(type, userId);
-    }
-
     public @Nullable UserCredentialTable getCredentialByUserHandle(final ByteArray userHandle) {
         return this.userCredentialDAO.getByUserHandle(CredentialType.WEBAUTHN, userHandle.getBase64());
     }

--- a/backend/src/main/java/io/papermc/hangar/components/auth/service/CredentialsService.java
+++ b/backend/src/main/java/io/papermc/hangar/components/auth/service/CredentialsService.java
@@ -50,6 +50,10 @@ public class CredentialsService extends HangarComponent {
         return this.userCredentialDAO.getByType(type, userId);
     }
 
+    public List<UserCredentialTable> getAllCredentials(final long userId, final CredentialType type) {
+        return this.userCredentialDAO.getAllByType(type, userId);
+    }
+
     public @Nullable UserCredentialTable getCredentialByUserHandle(final ByteArray userHandle) {
         return this.userCredentialDAO.getByUserHandle(CredentialType.WEBAUTHN, userHandle.getBase64());
     }

--- a/backend/src/main/java/io/papermc/hangar/components/auth/service/CredentialsService.java
+++ b/backend/src/main/java/io/papermc/hangar/components/auth/service/CredentialsService.java
@@ -9,6 +9,7 @@ import io.papermc.hangar.components.auth.model.credential.Credential;
 import io.papermc.hangar.components.auth.model.credential.CredentialType;
 import io.papermc.hangar.components.auth.model.credential.PasswordCredential;
 import io.papermc.hangar.components.auth.model.credential.TotpCredential;
+import io.papermc.hangar.components.auth.model.credential.WebAuthNCredential;
 import io.papermc.hangar.components.auth.model.db.UserCredentialTable;
 import io.papermc.hangar.db.customtypes.JSONB;
 import io.papermc.hangar.model.db.UserTable;
@@ -141,5 +142,21 @@ public class CredentialsService extends HangarComponent {
         } else {
             return 2;
         }
+    }
+
+    public boolean isOAuthOnly(final long userId) {
+        // no pw, no totp
+        if (this.getCredential(userId, CredentialType.PASSWORD) == null &&
+            this.getCredential(userId, CredentialType.TOTP) == null) {
+            final UserCredentialTable credential = this.getCredential(userId, CredentialType.WEBAUTHN);
+            // either no webauthn
+            if(credential == null) {
+                return true;
+            }
+            // or not correctly setup webauthn
+            final WebAuthNCredential webAuthNCredential = credential.getCredential().get(WebAuthNCredential.class);
+            return webAuthNCredential == null || webAuthNCredential.credentials().isEmpty();
+        }
+        return false;
     }
 }

--- a/backend/src/main/java/io/papermc/hangar/components/auth/service/CredentialsService.java
+++ b/backend/src/main/java/io/papermc/hangar/components/auth/service/CredentialsService.java
@@ -42,8 +42,8 @@ public class CredentialsService extends HangarComponent {
         this.userCredentialDAO.remove(userId, type);
     }
 
-    public void updateCredential(final long userId, final Credential credential) {
-        this.userCredentialDAO.update(userId, new JSONB(credential), credential.type());
+    public boolean updateCredential(final long userId, final Credential credential) {
+        return this.userCredentialDAO.update(userId, new JSONB(credential), credential.type());
     }
 
     public @Nullable UserCredentialTable getCredential(final long userId, final CredentialType type) {

--- a/backend/src/main/java/io/papermc/hangar/components/auth/service/OAuthService.java
+++ b/backend/src/main/java/io/papermc/hangar/components/auth/service/OAuthService.java
@@ -2,6 +2,7 @@ package io.papermc.hangar.components.auth.service;
 
 import com.auth0.jwt.JWT;
 import com.auth0.jwt.algorithms.Algorithm;
+import com.auth0.jwt.interfaces.DecodedJWT;
 import io.papermc.hangar.HangarComponent;
 import io.papermc.hangar.components.auth.dao.UserCredentialDAO;
 import io.papermc.hangar.components.auth.model.credential.CredentialType;
@@ -16,6 +17,7 @@ import io.papermc.hangar.db.customtypes.JSONB;
 import io.papermc.hangar.db.dao.internal.table.UserDAO;
 import io.papermc.hangar.exceptions.HangarApiException;
 import io.papermc.hangar.model.db.UserTable;
+import jakarta.annotation.PostConstruct;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.HashMap;
@@ -24,6 +26,7 @@ import java.util.Map;
 import java.util.UUID;
 import org.jdbi.v3.core.mapper.JoinRow;
 import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.web.client.RestClient;
 import org.springframework.web.util.UriComponentsBuilder;
 
@@ -32,6 +35,7 @@ public class OAuthService extends HangarComponent {
 
     private final RestClient restClient;
     private final Algorithm algo;
+    private final JWT jwt;
     private final AuthService authService;
     private final UserDAO userDAO;
     private final VerificationService verificationService;
@@ -40,15 +44,47 @@ public class OAuthService extends HangarComponent {
 
     private final Map<String, OAuthProvider> providers = new HashMap<>();
 
-    public OAuthService(final RestClient restClient, final Algorithm algo, final AuthService authService, final UserDAO userDAO, final VerificationService verificationService, final UserCredentialDAO userCredentialDAO, final CredentialsService credentialsService) {
+    public OAuthService(final RestClient restClient, final Algorithm algo, JWT jwt, final AuthService authService, final UserDAO userDAO, final VerificationService verificationService, final UserCredentialDAO userCredentialDAO, final CredentialsService credentialsService) {
         this.restClient = restClient;
         this.algo = algo;
+        this.jwt = jwt;
         this.authService = authService;
         this.userDAO = userDAO;
         this.verificationService = verificationService;
         this.userCredentialDAO = userCredentialDAO;
         this.credentialsService = credentialsService;
-        this.providers.put("github", new OAuthProvider("github", "26ba07861a06dda93f56", "d0cb6980a7c647b95cd30f8a2d6ac98b79cd67ac", new String[]{"user:email"}));
+    }
+
+    @PostConstruct
+    private void setup() {
+        this.config.security.oAuthProviders().forEach(this::setupProvider);
+    }
+
+    private void setupProvider(final OAuthProvider provider) {
+        this.providers.put(provider.name(), provider);
+        switch (provider.mode()) {
+            case OIDC -> {
+                if (provider.wellKnown() == null) {
+                    throw new IllegalArgumentException("Provider " + provider.name() + " is missing well-known url");
+                }
+                // noinspection unchecked
+                final Map<String, String> info = this.restClient.get().uri(provider.wellKnown())
+                    .retrieve()
+                    .body(Map.class);
+                if (info == null) {
+                    throw new IllegalStateException("Error in oauth well-known response for provider " + provider.name());
+                }
+                provider.authorizationEndpoint(info.get("authorization_endpoint"));
+                provider.tokenEndpoint(info.get("token_endpoint"));
+                provider.userInfoEndpoint(info.get("userinfo_endpoint"));
+            }
+            case GITHUB -> {
+                provider.authorizationEndpoint("https://github.com/login/oauth/authorize");
+                provider.tokenEndpoint("https://github.com/login/oauth/access_token");
+                provider.userInfoEndpoint(""); // TODO
+            }
+            default -> throw new IllegalArgumentException("Unknown provider mode: " + provider.mode());
+        }
     }
 
     public String oauthState(final Long user, final OAuthMode mode, final String returnUrl) {
@@ -79,60 +115,90 @@ public class OAuthService extends HangarComponent {
             throw new IllegalArgumentException("Unknown provider: " + provider);
         }
 
-        // todo get from provider
-        return UriComponentsBuilder.fromHttpUrl("https://github.com/login/oauth/authorize")
+        final UriComponentsBuilder builder = UriComponentsBuilder.fromHttpUrl(oAuthProvider.authorizationEndpoint())
             .queryParam("client_id", oAuthProvider.clientId())
-            .queryParam("redirect_uri", "http://localhost:3333/api/internal/oauth/" + oAuthProvider.name() + "/callback")
-            .queryParam("scope", String.join(",", oAuthProvider.scopes()))
-            .queryParam("state", state)
+            .queryParam("redirect_uri", this.config.getBaseUrl() + "/api/internal/oauth/" + oAuthProvider.name() + "/callback")
+            .queryParam("scope", String.join("+", oAuthProvider.scopes()))
+            .queryParam("state", state);
+
+        if (oAuthProvider.mode() == OAuthProvider.Mode.OIDC) {
+            builder.queryParam("response_type", "code");
+        }
+
+        return builder
             .build().toUriString();
     }
 
-    public String redeemCode(final String provider, final String code) {
+    public OAuthCodeResponse redeemCode(final String provider, final String code) {
         final OAuthProvider oAuthProvider = this.providers.get(provider);
         if (oAuthProvider == null) {
             throw new IllegalArgumentException("Unknown provider: " + provider);
         }
 
-        // todo get from provider
-        final OAuthCodeResponse response = this.restClient.post().uri("https://github.com/login/oauth/access_token")
-            .header("Accept", "application/json")
-            .body(new OAuthCodeRequest(oAuthProvider.clientId(), oAuthProvider.clientSecret(), code))
-            .retrieve()
-            .body(OAuthCodeResponse.class);
+        final OAuthCodeResponse response = switch (oAuthProvider.mode()) {
+            case OIDC -> this.restClient.post().uri(oAuthProvider.tokenEndpoint())
+                .header("Accept", "application/json")
+                .header("Content-Type", "application/x-www-form-urlencoded")
+                .body(new LinkedMultiValueMap<>(Map.of(
+                    "client_id", List.of(oAuthProvider.clientId()),
+                    "client_secret", List.of(oAuthProvider.clientSecret()),
+                    "code", List.of(code),
+                    "grant_type", List.of("authorization_code"),
+                    "redirect_uri", List.of(this.config.getBaseUrl() + "/api/internal/oauth/" + oAuthProvider.name() + "/callback")
+                )))
+                .retrieve()
+                .body(OAuthCodeResponse.class);
+            case GITHUB -> this.restClient.post().uri("https://github.com/login/oauth/access_token")
+                .header("Accept", "application/json")
+                .body(new OAuthCodeRequest(oAuthProvider.clientId(), oAuthProvider.clientSecret(), code))
+                .retrieve()
+                .body(OAuthCodeResponse.class);
+        };
 
         if (response == null) {
             throw new IllegalStateException("Error in oauth code response");
         }
-        return response.accessToken();
+        return response;
     }
 
-    public OAuthUserDetails getUserDetails(final String provider, final String token) {
+    public OAuthUserDetails getUserDetails(final String provider, final OAuthCodeResponse codeResponse) {
         final OAuthProvider oAuthProvider = this.providers.get(provider);
         if (oAuthProvider == null) {
             throw new IllegalArgumentException("Unknown provider: " + provider);
         }
 
-        // todo get from provider
-        // noinspection unchecked
-        final Map<String, String> response = this.restClient.get().uri("https://api.github.com/user")
-            .header("Authorization", "Bearer " + token)
-            .retrieve()
-            .body(Map.class);
+        return switch (oAuthProvider.mode()) {
+            case OIDC -> {
+                final DecodedJWT idToken = this.jwt.decodeJwt(codeResponse.idToken());
+                String name = idToken.getClaim("preferred_username").asString();
+                if (name == null) {
+                    name = idToken.getClaim("name").asString();
+                }
+                yield new OAuthUserDetails(idToken.getSubject(), name, idToken.getClaim("email").asString());
+            }
+            case GITHUB -> {
+                // noinspection unchecked
+                final Map<String, String> response = this.restClient.get().uri("https://api.github.com/user")
+                    .header("Authorization", "Bearer " + codeResponse.accessToken())
+                    .retrieve()
+                    .body(Map.class);
 
-        if (response == null) {
-            throw new IllegalStateException("Error in oauth code response");
-        }
+                if (response == null) {
+                    throw new IllegalStateException("Error in oauth code response");
+                }
 
-        // todo get from provider
-        // noinspection rawtypes
-        final List response2 = this.restClient.get().uri("https://api.github.com/user/emails")
-            .header("Authorization", "Bearer " + token)
-            .retrieve()
-            .body(List.class);
+                // noinspection rawtypes
+                final List response2 = this.restClient.get().uri("https://api.github.com/user/emails")
+                    .header("Authorization", "Bearer " + codeResponse.accessToken())
+                    .retrieve()
+                    .body(List.class);
 
-        // noinspection unchecked
-        return new OAuthUserDetails(String.valueOf(response.get("id")), response.get("login"), (String) ((Map<String, Object>) response2.stream().filter(e -> ((Map<String, Boolean>) e).get("primary")).findFirst().orElseThrow()).get("email"));
+                // noinspection unchecked
+                yield new OAuthUserDetails(String.valueOf(response.get("id")),
+                    response.get("login"),
+                    (String) ((Map<String, Object>) response2.stream().filter(e -> ((Map<String, Boolean>) e).get("primary")).findFirst().orElseThrow()).get("email"));
+            }
+        };
     }
 
     public UserTable register(final String provider, final String id, final String username, final String email, final boolean tos, final boolean emailVerified) {
@@ -142,7 +208,7 @@ public class OAuthService extends HangarComponent {
             throw new HangarApiException("This " + provider + " account is already linked to a Hangar account");
         }
 
-        final UserTable userTable = this.userDAO.create(UUID.randomUUID(), username, email, null, "en", List.of(), false, "light", false, new JSONB(Map.of()));
+        final UserTable userTable = this.userDAO.create(UUID.randomUUID(), username, email, null, "en", List.of(), false, "light", emailVerified, new JSONB(Map.of()));
 
         if (!emailVerified) {
             this.verificationService.sendVerificationCode(userTable.getUserId(), userTable.getEmail(), userTable.getName());
@@ -186,7 +252,7 @@ public class OAuthService extends HangarComponent {
         }
 
         final long userId = this.getHangarPrincipal().getUserId();
-        final boolean hasPassword = this.credentialsService.getCredential(userId, CredentialType.TOTP) != null;
+        final boolean hasPassword = this.credentialsService.getCredential(userId, CredentialType.PASSWORD) != null;
         final long oauthCreds = this.userCredentialDAO.countByType(userId, CredentialType.OAUTH);
         if (!hasPassword && oauthCreds == 1) {
             throw new HangarApiException("You can't remove your last oauth account without having a password set");

--- a/backend/src/main/java/io/papermc/hangar/components/auth/service/OAuthService.java
+++ b/backend/src/main/java/io/papermc/hangar/components/auth/service/OAuthService.java
@@ -1,0 +1,179 @@
+package io.papermc.hangar.components.auth.service;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.algorithms.Algorithm;
+import io.papermc.hangar.HangarComponent;
+import io.papermc.hangar.components.auth.dao.UserCredentialDAO;
+import io.papermc.hangar.components.auth.model.credential.CredentialType;
+import io.papermc.hangar.components.auth.model.credential.OAuthCredential;
+import io.papermc.hangar.components.auth.model.db.UserCredentialTable;
+import io.papermc.hangar.components.auth.model.oauth.OAuthCodeRequest;
+import io.papermc.hangar.components.auth.model.oauth.OAuthCodeResponse;
+import io.papermc.hangar.components.auth.model.oauth.OAuthMode;
+import io.papermc.hangar.components.auth.model.oauth.OAuthProvider;
+import io.papermc.hangar.components.auth.model.oauth.OAuthUserDetails;
+import io.papermc.hangar.db.customtypes.JSONB;
+import io.papermc.hangar.db.dao.internal.table.UserDAO;
+import io.papermc.hangar.exceptions.HangarApiException;
+import io.papermc.hangar.model.db.UserTable;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.jdbi.v3.core.mapper.JoinRow;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.util.UriComponentsBuilder;
+
+@Service
+public class OAuthService extends HangarComponent {
+
+    private final RestClient restClient;
+    private final Algorithm algo;
+    private final AuthService authService;
+    private final UserDAO userDAO;
+    private final VerificationService verificationService;
+    private final UserCredentialDAO userCredentialDAO;
+
+    private final Map<String, OAuthProvider> providers = new HashMap<>();
+
+    public OAuthService(final RestClient restClient, final Algorithm algo, final AuthService authService, final UserDAO userDAO, final VerificationService verificationService, final UserCredentialDAO userCredentialDAO) {
+        this.restClient = restClient;
+        this.algo = algo;
+        this.authService = authService;
+        this.userDAO = userDAO;
+        this.verificationService = verificationService;
+        this.userCredentialDAO = userCredentialDAO;
+        this.providers.put("github", new OAuthProvider("github", "26ba07861a06dda93f56", "d0cb6980a7c647b95cd30f8a2d6ac98b79cd67ac", new String[]{"user:email"}));
+    }
+
+    public String oauthState(final Long user, final OAuthMode mode, final String returnUrl) {
+        return JWT.create()
+            .withIssuer(this.config.security.tokenIssuer())
+            .withExpiresAt(Instant.now().plus(10, ChronoUnit.MINUTES))
+            .withSubject(String.valueOf(user))
+            .withClaim("mode", mode.name())
+            .withClaim("returnUrl", returnUrl)
+            .sign(this.algo);
+    }
+
+    public String getLoginUrl(final String provider, final String state) {
+        final OAuthProvider oAuthProvider = this.providers.get(provider);
+        if (oAuthProvider == null) {
+            throw new IllegalArgumentException("Unknown provider: " + provider);
+        }
+
+        // todo get from provider
+        return UriComponentsBuilder.fromHttpUrl("https://github.com/login/oauth/authorize")
+            .queryParam("client_id", oAuthProvider.clientId())
+            .queryParam("redirect_uri", "http://localhost:3333/api/internal/oauth/" + oAuthProvider.name() + "/callback")
+            .queryParam("scope", String.join(",", oAuthProvider.scopes()))
+            .queryParam("state", state)
+            .build().toUriString();
+    }
+
+    public String redeemCode(final String provider, final String code) {
+        final OAuthProvider oAuthProvider = this.providers.get(provider);
+        if (oAuthProvider == null) {
+            throw new IllegalArgumentException("Unknown provider: " + provider);
+        }
+
+        // todo get from provider
+        final OAuthCodeResponse response = this.restClient.post().uri("https://github.com/login/oauth/access_token")
+            .header("Accept", "application/json")
+            .body(new OAuthCodeRequest(oAuthProvider.clientId(), oAuthProvider.clientSecret(), code))
+            .retrieve()
+            .body(OAuthCodeResponse.class);
+
+        if (response == null) {
+            throw new IllegalStateException("Error in oauth code response");
+        }
+        return response.accessToken();
+    }
+
+    public OAuthUserDetails getUserDetails(final String provider, final String token) {
+        final OAuthProvider oAuthProvider = this.providers.get(provider);
+        if (oAuthProvider == null) {
+            throw new IllegalArgumentException("Unknown provider: " + provider);
+        }
+
+        // todo get from provider
+        // noinspection unchecked
+        final Map<String, String> response = this.restClient.get().uri("https://api.github.com/user")
+            .header("Authorization", "Bearer " + token)
+            .retrieve()
+            .body(Map.class);
+
+        if (response == null) {
+            throw new IllegalStateException("Error in oauth code response");
+        }
+
+        // todo get from provider
+        // noinspection rawtypes
+        final List response2 = this.restClient.get().uri("https://api.github.com/user/emails")
+            .header("Authorization", "Bearer " + token)
+            .retrieve()
+            .body(List.class);
+
+        // noinspection unchecked
+        return new OAuthUserDetails(String.valueOf(response.get("id")), response.get("login"), (String) ((Map<String, Object>) response2.stream().filter(e -> ((Map<String, Boolean>) e).get("primary")).findFirst().orElseThrow()).get("email"));
+    }
+
+    public UserTable register(final String provider, final String id, final String username, final String email, final boolean tos, final boolean emailVerified) {
+        this.authService.validateNewUser(username, email, tos);
+
+        if (this.userCredentialDAO.getOAuthUser(provider, id) != null) {
+            throw new HangarApiException("This " + provider + " account is already linked to a Hangar account");
+        }
+
+        final UserTable userTable = this.userDAO.create(UUID.randomUUID(), username, email, null, "en", List.of(), false, "light", false, new JSONB(Map.of()));
+
+        if (!emailVerified) {
+            this.verificationService.sendVerificationCode(userTable.getUserId(), userTable.getEmail(), userTable.getName());
+        }
+
+        return userTable;
+    }
+
+    public Map<String, OAuthProvider> getProviders() {
+        return this.providers;
+    }
+
+    public UserTable login(final String provider, final String id, final String name) {
+        final JoinRow result = this.userCredentialDAO.getOAuthUser(provider, id);
+        if (result == null) {
+            return null;
+        }
+
+        final UserCredentialTable userCredentialTable = result.get(UserCredentialTable.class);
+        final UserTable userTable = result.get(UserTable.class);
+        if (userCredentialTable == null || userTable == null) {
+            return null;
+        }
+
+        final OAuthCredential oAuthCredential = userCredentialTable.getCredential().get(OAuthCredential.class);
+        if (oAuthCredential == null) {
+            return null;
+        }
+
+        if (!name.equals(oAuthCredential.name())) {
+            this.userCredentialDAO.updateOAuth(userTable.getUserId(), new JSONB(new OAuthCredential(provider, id, name)), CredentialType.OAUTH, provider, id);
+        }
+
+        return userTable;
+    }
+
+    public String unlink(final String provider, final String id) {
+        final OAuthProvider oAuthProvider = this.providers.get(provider);
+        if (oAuthProvider == null) {
+            throw new IllegalArgumentException("Unknown provider: " + provider);
+        }
+
+        this.userCredentialDAO.removeOAuth(this.getHangarPrincipal().getUserId(), CredentialType.OAUTH, provider, id);
+
+        // TODO get from provider
+        return "https://github.com/settings/connections/applications/" + oAuthProvider.clientId();
+    }
+}

--- a/backend/src/main/java/io/papermc/hangar/components/auth/service/TokenService.java
+++ b/backend/src/main/java/io/papermc/hangar/components/auth/service/TokenService.java
@@ -6,6 +6,7 @@ import com.auth0.jwt.algorithms.Algorithm;
 import com.auth0.jwt.interfaces.DecodedJWT;
 import io.papermc.hangar.HangarComponent;
 import io.papermc.hangar.components.auth.dao.UserRefreshTokenDAO;
+import io.papermc.hangar.components.auth.model.credential.CredentialType;
 import io.papermc.hangar.components.auth.model.db.UserRefreshToken;
 import io.papermc.hangar.db.dao.internal.table.auth.ApiKeyDAO;
 import io.papermc.hangar.exceptions.HangarApiException;
@@ -98,8 +99,12 @@ public class TokenService extends HangarComponent {
         }
         // in any case, refreshing the cookie is good
         this.addCookie(SecurityConfig.REFRESH_COOKIE_NAME, userRefreshToken.getToken().toString(), this.config.security.refreshTokenExpiry().toSeconds(), true, this.response);
+
+        // oauth only users are always privileged
+        final boolean privileged = this.credentialsService.isOAuthOnly(userTable.getUserId());
+
         // then issue a new access token
-        return new RefreshResponse(this.newToken0(userTable, false), userTable);
+        return new RefreshResponse(this.newToken0(userTable, privileged), userTable);
     }
 
     public void invalidateToken(final String refreshToken) {

--- a/backend/src/main/java/io/papermc/hangar/components/auth/service/VerificationService.java
+++ b/backend/src/main/java/io/papermc/hangar/components/auth/service/VerificationService.java
@@ -66,6 +66,9 @@ public class VerificationService extends HangarComponent {
         if (userTable == null) {
             return;
         }
+        if (!userTable.isEmailVerified()) {
+            return;
+        }
 
         this.verificationCodeDao.deleteOld(VerificationCodeTable.VerificationCodeType.PASSWORD_RESET, userTable.getUserId());
 

--- a/backend/src/main/java/io/papermc/hangar/config/WebConfig.java
+++ b/backend/src/main/java/io/papermc/hangar/config/WebConfig.java
@@ -139,7 +139,7 @@ public class WebConfig extends WebMvcConfigurationSupport {
             AnnotationIntrospector.pair(sAnnotationIntrospector, new HangarAnnotationIntrospector()),
             this.mapper.getDeserializationConfig().getAnnotationIntrospector()
         );
-        converters.add(new MappingJackson2HttpMessageConverter(this.mapper));
+        converters.add(this.mappingJackson2HttpMessageConverter(this.mapper));
         this.addDefaultHttpMessageConverters(converters);
     }
 
@@ -228,7 +228,7 @@ public class WebConfig extends WebMvcConfigurationSupport {
     static class LoggingInterceptor implements ClientHttpRequestInterceptor {
 
         @Override
-        public ClientHttpResponse intercept(final HttpRequest req, final byte[] reqBody, final ClientHttpRequestExecution ex) throws IOException {
+        public @NotNull ClientHttpResponse intercept(final @NotNull HttpRequest req, final byte @NotNull [] reqBody, final @NotNull ClientHttpRequestExecution ex) throws IOException {
             if (interceptorLogger.isDebugEnabled()) {
                 interceptorLogger.debug("Request {}, body {}, headers {}", req.getMethod() + " " + req.getURI(), new String(reqBody, StandardCharsets.UTF_8), req.getHeaders());
             }

--- a/backend/src/main/java/io/papermc/hangar/config/hangar/HangarSecurityConfig.java
+++ b/backend/src/main/java/io/papermc/hangar/config/hangar/HangarSecurityConfig.java
@@ -1,11 +1,11 @@
 package io.papermc.hangar.config.hangar;
 
+import io.papermc.hangar.components.auth.model.oauth.OAuthProvider;
 import java.net.URI;
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.boot.context.properties.NestedConfigurationProperty;
 import org.springframework.boot.context.properties.bind.DefaultValue;
 import org.springframework.boot.convert.DurationUnit;
 
@@ -19,7 +19,8 @@ public record HangarSecurityConfig(
     @DurationUnit(ChronoUnit.SECONDS) Duration tokenExpiry,
     @DurationUnit(ChronoUnit.DAYS) Duration refreshTokenExpiry,
     String rpName,
-    String rpId
+    String rpId,
+    List<OAuthProvider> oAuthProviders
 ) {
 
     public boolean checkSafe(final String url) {

--- a/backend/src/main/java/io/papermc/hangar/controller/internal/BackendDataController.java
+++ b/backend/src/main/java/io/papermc/hangar/controller/internal/BackendDataController.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.introspect.JacksonAnnotationIntrospector;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.papermc.hangar.HangarComponent;
+import io.papermc.hangar.components.auth.service.OAuthService;
 import io.papermc.hangar.config.CacheConfig;
 import io.papermc.hangar.config.hangar.HangarConfig;
 import io.papermc.hangar.db.customtypes.RoleCategory;
@@ -53,14 +54,16 @@ public class BackendDataController extends HangarComponent {
     private final PlatformService platformService;
     private final Optional<GitProperties> gitProperties;
     private final RolesDAO rolesDAO;
+    private final OAuthService oAuthService;
 
     @Autowired
-    public BackendDataController(final ObjectMapper mapper, final HangarConfig config, final PlatformService platformService, final Optional<GitProperties> gitProperties, final RolesDAO rolesDAO) {
+    public BackendDataController(final ObjectMapper mapper, final HangarConfig config, final PlatformService platformService, final Optional<GitProperties> gitProperties, final RolesDAO rolesDAO, OAuthService oAuthService) {
         this.config = config;
         this.objectMapper = mapper.copy();
         this.platformService = platformService;
         this.gitProperties = gitProperties;
         this.rolesDAO = rolesDAO;
+        this.oAuthService = oAuthService;
         this.objectMapper.setAnnotationIntrospector(new JacksonAnnotationIntrospector() {
             @Override
             protected <A extends Annotation> A _findAnnotation(final Annotated annotated, final Class<A> annoClass) {
@@ -233,6 +236,6 @@ public class BackendDataController extends HangarComponent {
     @GetMapping("/security")
     @ResponseBody
     public Security getSecurity() {
-        return new Security(this.config.security.safeDownloadHosts());
+        return new Security(this.config.security.safeDownloadHosts(), this.oAuthService.getProviders().keySet());
     }
 }

--- a/backend/src/main/java/io/papermc/hangar/controller/internal/HangarUserController.java
+++ b/backend/src/main/java/io/papermc/hangar/controller/internal/HangarUserController.java
@@ -114,7 +114,7 @@ public class HangarUserController extends HangarComponent {
     @GetMapping("/users/@me")
     public ResponseEntity<?> getCurrentUser(final HangarAuthenticationToken hangarAuthenticationToken, @CookieValue(name = SecurityConfig.REFRESH_COOKIE_NAME, required = false) final String refreshToken) {
         final String token;
-        final String name;
+        final long id;
         if (hangarAuthenticationToken == null) {
             // if we don't have a token, lets see if we can get one via our refresh token
             if (refreshToken == null) {
@@ -124,7 +124,7 @@ public class HangarUserController extends HangarComponent {
             try {
                 final TokenService.RefreshResponse refreshResponse = this.tokenService.refreshAccessToken(refreshToken);
                 token = refreshResponse.accessToken();
-                name = refreshResponse.userTable().getName();
+                id = refreshResponse.userTable().getUserId();
             } catch (final HangarApiException ex) {
                 // no token + no valid refresh token -> no content
                 return ResponseEntity.noContent().build();
@@ -132,10 +132,10 @@ public class HangarUserController extends HangarComponent {
         } else {
             // when we have a token, just use that
             token = hangarAuthenticationToken.getCredentials().getToken();
-            name = hangarAuthenticationToken.getName();
+            id = hangarAuthenticationToken.getUserId();
         }
         // get user
-        final HangarUser user = this.usersApiService.getUser(name, HangarUser.class);
+        final HangarUser user = this.usersApiService.getUser(id, HangarUser.class);
         user.setAccessToken(token);
         user.setAal(this.credentialsService.getAal(Objects.requireNonNull(this.userService.getUserTable(user.getId()))));
         return ResponseEntity.ok(user);

--- a/backend/src/main/java/io/papermc/hangar/model/internal/api/responses/Security.java
+++ b/backend/src/main/java/io/papermc/hangar/model/internal/api/responses/Security.java
@@ -1,6 +1,7 @@
 package io.papermc.hangar.model.internal.api.responses;
 
 import java.util.List;
+import java.util.Set;
 
-public record Security(List<String> safeDownloadHosts) {
+public record Security(List<String> safeDownloadHosts, Set<String> oauthProviders) {
 }

--- a/backend/src/main/java/io/papermc/hangar/security/configs/SecurityConfig.java
+++ b/backend/src/main/java/io/papermc/hangar/security/configs/SecurityConfig.java
@@ -12,6 +12,7 @@ import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.ProviderManager;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.security.web.SecurityFilterChain;
@@ -26,6 +27,8 @@ import org.springframework.security.web.util.matcher.RequestMatcher;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import org.springframework.web.filter.CorsFilter;
+
+import static org.springframework.security.config.Customizer.*;
 
 @Configuration
 @EnableWebSecurity
@@ -56,18 +59,18 @@ public class SecurityConfig {
     public SecurityFilterChain securityFilterChain(final HttpSecurity http, final AuthenticationManager authenticationManagerBean) throws Exception {
         http
             // Disable default configurations
-            .logout().disable()
-            .httpBasic().disable()
-            .formLogin().disable()
+            .logout(AbstractHttpConfigurer::disable)
+            .httpBasic(AbstractHttpConfigurer::disable)
+            .formLogin(AbstractHttpConfigurer::disable)
 
             // Disable session creation
-            .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS).and()
+            .sessionManagement(s -> s.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
 
             // Disable csrf (shouldn't need it as its just a backend api now)
-            .csrf().disable()
+            .csrf(AbstractHttpConfigurer::disable)
 
             // Enable cors
-            .cors().and()
+            .cors(withDefaults())
 
             // Custom auth filters
             .addFilterBefore(new HangarAuthenticationFilter(
@@ -79,7 +82,7 @@ public class SecurityConfig {
             )
 
             // Permit all (use method security for controller access)
-            .authorizeRequests().anyRequest().permitAll();
+            .authorizeHttpRequests(s-> s.anyRequest().permitAll());
 
         return http.build();
     }

--- a/backend/src/main/java/io/papermc/hangar/service/api/UsersApiService.java
+++ b/backend/src/main/java/io/papermc/hangar/service/api/UsersApiService.java
@@ -74,6 +74,13 @@ public class UsersApiService extends HangarComponent {
         return user instanceof HangarUser ? (T) this.supplyHeaderData((HangarUser) user) : user;
     }
 
+    public <T extends User> T getUser(final long id, final Class<T> type) {
+        final T user = this.getUserRequired(id, this.usersDAO::getUser, type);
+        this.supplyNameHistory(user);
+        this.supplyAvatarUrl(user);
+        return user instanceof HangarUser ? (T) this.supplyHeaderData((HangarUser) user) : user;
+    }
+
     @Transactional(readOnly = true)
     public <T extends User> PaginatedResult<T> getUsers(final String query, final RequestPagination pagination, final Class<T> type) {
         final boolean hasQuery = !StringUtils.isBlank(query);

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -194,6 +194,7 @@ hangar:
         client-secret: "d0cb6980a7c647b95cd30f8a2d6ac98b79cd67ac"
         scopes:
         - "user:email"
+        unlink-link: "https://github.com/settings/connections/applications/:id"
       - name: "microsoft"
         mode: "oidc"
         client-id: "93147315-cd13-411a-8068-90e912c6e242"
@@ -203,6 +204,7 @@ hangar:
         - "email"
         - "profile"
         well-known: "https://login.microsoftonline.com/common/v2.0/.well-known/openid-configuration"
+        unlink-link: "https://account.live.com/consent/Manage"
       - name: "google"
         mode: "oidc"
         client-id: "731781739823-2gdq4irf8o50ktsctn358j5bd1an5r0k.apps.googleusercontent.com"
@@ -212,6 +214,7 @@ hangar:
           - "email"
           - "profile"
         well-known: "https://accounts.google.com/.well-known/openid-configuration"
+        unlink-link: "https://myaccount.google.com/connections"
 
   jobs:
     check-interval: 5s

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -187,6 +187,31 @@ hangar:
       - "giphy.com"
       - "media.giphy.com"
       - "bstats.org"
+    o-auth-providers:
+      - name: "github"
+        mode: "github"
+        client-id: "26ba07861a06dda93f56"
+        client-secret: "d0cb6980a7c647b95cd30f8a2d6ac98b79cd67ac"
+        scopes:
+        - "user:email"
+      - name: "microsoft"
+        mode: "oidc"
+        client-id: "93147315-cd13-411a-8068-90e912c6e242"
+        client-secret: "L4l8Q~AVLEy5nSp0_q4qm2a8z1DrODJhJGb4cbjc"
+        scopes:
+        - "openid"
+        - "email"
+        - "profile"
+        well-known: "https://login.microsoftonline.com/common/v2.0/.well-known/openid-configuration"
+      - name: "google"
+        mode: "oidc"
+        client-id: "731781739823-2gdq4irf8o50ktsctn358j5bd1an5r0k.apps.googleusercontent.com"
+        client-secret: "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"
+        scopes:
+          - "openid"
+          - "email"
+          - "profile"
+        well-known: "https://accounts.google.com/.well-known/openid-configuration"
 
   jobs:
     check-interval: 5s

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -229,7 +229,7 @@ logging:
     org.springframework: INFO
     org.springframework.context.support.PostProcessorRegistrationDelegate: WARN
     io.papermc.hangar.service.internal.JobService: DEBUG
-    io.papermc.hangar.config.WebConfig.LoggingInterceptor: DEBUG
+    http-client-logger: INFO
     io.papermc.hangar.service.ReplicationService: DEBUG
     # graphql: TRACE
     # org.springframework.cache: TRACE

--- a/chart/templates/secret-hangar-backend.yaml
+++ b/chart/templates/secret-hangar-backend.yaml
@@ -57,6 +57,7 @@ stringData:
           client-secret: "{{ .Values.backend.config.githubClientSecret }}"
           scopes:
           - "user:email"
+          unlink-link: "https://github.com/settings/connections/applications/:id"
         - name: "microsoft"
           mode: "oidc"
           client-id: "{{ .Values.backend.config.microsoftClientId }}"
@@ -66,6 +67,7 @@ stringData:
           - "email"
           - "profile"
           well-known: "https://login.microsoftonline.com/common/v2.0/.well-known/openid-configuration"
+          unlink-link: "https://account.live.com/consent/Manage"
         - name: "google"
           mode: "oidc"
           client-id: "{{ .Values.backend.config.googleClientId }}"
@@ -75,6 +77,7 @@ stringData:
             - "email"
             - "profile"
           well-known: "https://accounts.google.com/.well-known/openid-configuration"
+          unlink-link: "https://myaccount.google.com/connections"
 
       storage:
         plugin-upload-dir: "/hangar/uploads"

--- a/chart/templates/secret-hangar-backend.yaml
+++ b/chart/templates/secret-hangar-backend.yaml
@@ -50,6 +50,31 @@ stringData:
       security:
         token-secret: "{{ .Values.backend.config.tokenSecret }}"
         rp-id: "{{ .Values.backend.config.rpId }}"
+        o-auth-providers:
+        - name: "github"
+          mode: "github"
+          client-id: "{{ .Values.backend.config.githubClientId }}"
+          client-secret: "{{ .Values.backend.config.githubClientSecret }}"
+          scopes:
+          - "user:email"
+        - name: "microsoft"
+          mode: "oidc"
+          client-id: "{{ .Values.backend.config.microsoftClientId }}"
+          client-secret: "{{ .Values.backend.config.microsoftClientSecret }}"
+          scopes:
+          - "openid"
+          - "email"
+          - "profile"
+          well-known: "https://login.microsoftonline.com/common/v2.0/.well-known/openid-configuration"
+        - name: "google"
+          mode: "oidc"
+          client-id: "{{ .Values.backend.config.googleClientId }}"
+          client-secret: "{{ .Values.backend.config.googleClientSecret }}"
+          scopes:
+            - "openid"
+            - "email"
+            - "profile"
+          well-known: "https://accounts.google.com/.well-known/openid-configuration"
 
       storage:
         plugin-upload-dir: "/hangar/uploads"

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -186,6 +186,12 @@ backend:
       options: "?currentSchema=hangar"
     tokenSecret: "secret"
     rpId: "localhost"
+    githubClientId: "todo"
+    githubClientSecret: "todo"
+    microsoftClientId: "todo"
+    microsoftClientSecret: "todo"
+    googleClientId: "todo"
+    googleClientSecret: "todo"
     sentry:
       dsn: "todo"
       environment: "todo"

--- a/frontend/src/components/design/Button.vue
+++ b/frontend/src/components/design/Button.vue
@@ -14,6 +14,7 @@ const props = withDefaults(
     buttonType?: "primary" | "secondary" | "red" | "transparent";
     loading?: boolean;
     to?: string | RouteLocationRaw | object;
+    href?: string;
   }>(),
   {
     disabled: false,
@@ -21,6 +22,7 @@ const props = withDefaults(
     buttonType: "primary",
     loading: false,
     to: undefined,
+    href: undefined,
   }
 );
 const paddingClass = computed<string>(() => {
@@ -54,7 +56,15 @@ const classes = computed<string>(() => {
 </script>
 
 <template>
-  <component :is="to ? NuxtLink : 'button'" :class="classes" :disabled="disabled || loading" :to="to" v-bind="$attrs" @click="$emit('click', $event)">
+  <component
+    :is="to ? NuxtLink : href ? 'a' : 'button'"
+    :class="classes"
+    :disabled="disabled || loading"
+    :to="to"
+    :href="href"
+    v-bind="$attrs"
+    @click="$emit('click', $event)"
+  >
     <slot></slot>
     <span v-if="loading" class="pl-1"><Spinner class="stroke-gray-400" :diameter="1" :stroke="0.01" unit="rem" /></span>
   </component>

--- a/frontend/src/composables/useAuth.ts
+++ b/frontend/src/composables/useAuth.ts
@@ -125,14 +125,14 @@ class Auth {
     store.invalidated = true;
   }
 
-  async updateUser(): Promise<void> {
+  async updateUser(force = false): Promise<void> {
     const authStore = useAuthStore();
     const axios = useAxios();
     if (authStore.invalidated) {
       authLog("no point in updating if we just invalidated");
       return;
     }
-    if (authStore.user) {
+    if (!force && authStore.user) {
       authLog("no point in updating if we already have a user");
       return;
     }

--- a/frontend/src/pages/auth/login.vue
+++ b/frontend/src/pages/auth/login.vue
@@ -16,6 +16,8 @@ import Card from "~/components/design/Card.vue";
 import Link from "~/components/design/Link.vue";
 import { required } from "~/composables/useValidationHelpers";
 import { useNotificationStore } from "~/store/notification";
+import { useBackendData } from "~/store/backendData";
+import IconMdiGitHub from "~icons/mdi/github";
 
 const route = useRoute();
 const router = useRouter();
@@ -23,6 +25,7 @@ const authStore = useAuthStore();
 const v = useVuelidate();
 const notification = useNotificationStore();
 const i18n = useI18n();
+const backendData = useBackendData;
 
 const loading = ref(false);
 const supportedMethods = ref([]);
@@ -148,8 +151,20 @@ useHead(useSeo("Login", null, route, null));
         :disabled="privileged"
       />
       <InputPassword v-model="password" label="Password" name="password" autocomplete="current-password" :rules="[required()]" />
-      <div>
+      <div class="flex gap-2">
         <Button :disabled="loading" @click.prevent="loginPassword">Login</Button>
+        <Button
+          v-for="provider in backendData.security.oauthProviders"
+          :key="provider"
+          :disabled="loading"
+          :href="'/api/internal/oauth/' + provider + '/login?mode=login&returnUrl=/'"
+        >
+          <template v-if="provider === 'github'">
+            <IconMdiGitHub class="mr-1" />
+            Login with GitHub
+          </template>
+          <template v-else> Login with {{ provider }} </template>
+        </Button>
       </div>
       <Link v-if="!privileged" button-type="secondary" to="/auth/signup" class="w-max">Don't have an account yet? Create one!</Link>
       <Link v-if="!privileged" to="/auth/reset" class="w-max">Forgot your password?</Link>

--- a/frontend/src/pages/auth/oauth-signup.vue
+++ b/frontend/src/pages/auth/oauth-signup.vue
@@ -1,0 +1,101 @@
+<script lang="ts" setup>
+import { useHead } from "@unhead/vue";
+import { useRoute } from "vue-router";
+import { reactive, ref, computed } from "vue";
+import { useVuelidate } from "@vuelidate/core";
+import { useI18n } from "vue-i18n";
+import { jwtDecode } from "jwt-decode";
+import { useSeo } from "~/composables/useSeo";
+import Card from "~/components/design/Card.vue";
+import InputText from "~/components/ui/InputText.vue";
+import Button from "~/components/design/Button.vue";
+import { useInternalApi } from "~/composables/useApi";
+import InputCheckbox from "~/components/ui/InputCheckbox.vue";
+import { email, required, sameAs } from "~/composables/useValidationHelpers";
+import { useNotificationStore } from "~/store/notification";
+import Link from "~/components/design/Link.vue";
+import InputGroup from "~/components/ui/InputGroup.vue";
+
+const route = useRoute();
+const v = useVuelidate();
+
+interface OAuthSignupForm {
+  username?: string;
+  email?: string;
+  jwt?: string;
+  tos?: boolean;
+}
+
+const done = ref(false);
+
+const notification = useNotificationStore();
+const i18n = useI18n();
+const form = reactive<OAuthSignupForm>({});
+const loading = ref(false);
+
+const errorMessage = ref<string | undefined>();
+const emailVerificationNeeded = ref(false);
+
+const data = computed(() =>
+  jwtDecode<{
+    email: string;
+    username: string;
+    provider: string;
+    returnUrl: string;
+  }>(route.query.state as string)
+);
+
+form.jwt = route.query.state as string;
+form.email = data.value.email;
+form.username = data.value.username;
+form.tos = false;
+
+async function submit() {
+  if (!(await v.value.$validate())) return;
+  loading.value = true;
+  errorMessage.value = undefined;
+  try {
+    const result = await useInternalApi<{ emailVerificationNeeded: boolean }>("oauth/register", "POST", form);
+    emailVerificationNeeded.value = result.emailVerificationNeeded;
+    done.value = true;
+  } catch (e) {
+    notification.fromError(i18n, e);
+  }
+  loading.value = false;
+}
+
+useHead(useSeo("OAuth Signup", null, route, null));
+</script>
+
+<template>
+  <Card class="w-xl mx-auto max-w-full">
+    <template #header>
+      <h1>OAuth Sign up</h1>
+    </template>
+
+    <form v-if="!done" class="flex flex-col gap-2">
+      <InputText v-model="form.username" label="Username" name="username" autocomplete="username" :rules="[required()]" />
+      <InputText v-model="form.email" type="email" label="E-Mail" name="email" autocomplete="email" :rules="[required(), email()]" />
+      <div v-if="errorMessage" class="c-red">{{ errorMessage }}</div>
+      <div class="w-max">
+        <InputGroup v-model="form.tos" :rules="[sameAs('You need to accept the Terms and Conditions')(true)]" :silent-errors="false" full-width>
+          <InputCheckbox v-model="form.tos">
+            <template #label>I agree to the&nbsp;<Link to="/terms">Terms and Conditions</Link></template>
+          </InputCheckbox>
+        </InputGroup>
+      </div>
+      <div>
+        <Button type="submit" :disabled="loading" @click.prevent="submit">Sign up using {{ data.provider }} account {{ data.username }}</Button>
+      </div>
+      <Link to="login">Login with existing account</Link>
+    </form>
+
+    <div v-if="done" class="flex flex-col gap-2">
+      <p>Your account has been created! <template v-if="emailVerificationNeeded">Please check your emails to complete the signup process.</template></p>
+      <div class="flex gap-2">
+        <Button v-if="data.returnUrl" :to="data.returnUrl">Back to last page</Button>
+        <Button to="/auth/settings/account">Go to account settings</Button>
+      </div>
+    </div>
+  </Card>
+</template>

--- a/frontend/src/pages/auth/settings/account.vue
+++ b/frontend/src/pages/auth/settings/account.vue
@@ -8,11 +8,12 @@ import { useAuthSettings } from "~/composables/useApiHelper";
 import Button from "~/components/design/Button.vue";
 import InputPassword from "~/components/ui/InputPassword.vue";
 import InputText from "~/components/ui/InputText.vue";
-import { email, required, useInternalApi } from "#imports";
+import { email, required, useAuth, useInternalApi } from "#imports";
 import PageTitle from "~/components/design/PageTitle.vue";
 
 const emit = defineEmits<{
-  openEmailConfirmModal: () => void;
+  openEmailConfirmModal: [];
+  refreshSettings: [];
 }>();
 
 const auth = useAuthStore();
@@ -41,6 +42,8 @@ async function saveAccount() {
     notification.success("Saved!");
     accountForm.currentPassword = "";
     accountForm.newPassword = "";
+    emit("refreshSettings");
+    useAuth.updateUser(true);
     v.value.$reset();
   } catch (e) {
     notification.fromError(i18n, e);
@@ -59,21 +62,23 @@ async function saveAccount() {
       <Button v-if="!settings?.emailConfirmed" class="w-max" size="small" :disabled="loading" @click.prevent="$emit('openEmailConfirmModal')">
         Verify email
       </Button>
-      <InputPassword
-        v-model="accountForm.currentPassword"
-        label="Current password"
-        name="current-password"
-        autofill="current-password"
-        autocomplete="current-password"
-        :rules="[required()]"
-      />
-      <InputPassword
-        v-model="accountForm.newPassword"
-        label="New password (optional)"
-        name="new-password"
-        autofill="new-password"
-        autocomplete="new-password"
-      />
+      <template v-if="settings?.hasPassword">
+        <InputPassword
+          v-model="accountForm.currentPassword"
+          label="Current password"
+          name="current-password"
+          autofill="current-password"
+          autocomplete="current-password"
+          :rules="[required()]"
+        />
+        <InputPassword
+          v-model="accountForm.newPassword"
+          label="New password (optional)"
+          name="new-password"
+          autofill="new-password"
+          autocomplete="new-password"
+        />
+      </template>
       <div v-if="error" class="text-red">{{ error }}</div>
       <Button type="submit" class="w-max" :disabled="loading" @click.prevent="saveAccount">Save</Button>
     </form>

--- a/frontend/src/pages/auth/settings/security.vue
+++ b/frontend/src/pages/auth/settings/security.vue
@@ -19,7 +19,7 @@ import PrettyTime from "~/components/design/PrettyTime.vue";
 import { useBackendData } from "~/store/backendData";
 import IconMdiGitHub from "~icons/mdi/github";
 
-const props = defineProps<{
+defineProps<{
   settings?: AuthSettings;
 }>();
 const emit = defineEmits<{
@@ -350,11 +350,11 @@ function closeUnlinkModal() {
     </div>
     <div class="flex gap-2 mt-2">
       <Button
-        v-for="credential in settings?.oAuthCredentials"
+        v-for="credential in settings?.oauthConnections"
         :key="credential.provider + credential.id"
-        :disabled="!settings?.hasPassword && settings?.oAuthCredentials.length === 1"
+        :disabled="!settings?.hasPassword && settings?.oauthConnections.length === 1"
         :title="
-          !settings?.hasPassword && settings?.oAuthCredentials.length === 1
+          !settings?.hasPassword && settings?.oauthConnections.length === 1
             ? 'You can\'t unlink your last oauth credential if you don\'t have a password set'
             : undefined
         "

--- a/frontend/src/pages/auth/signup.vue
+++ b/frontend/src/pages/auth/signup.vue
@@ -15,10 +15,13 @@ import { email, required, sameAs } from "~/composables/useValidationHelpers";
 import { useNotificationStore } from "~/store/notification";
 import Link from "~/components/design/Link.vue";
 import InputGroup from "~/components/ui/InputGroup.vue";
+import { useBackendData } from "~/store/backendData";
+import IconMdiGitHub from "~icons/mdi/github";
 
 const route = useRoute();
 const router = useRouter();
 const v = useVuelidate();
+const backendData = useBackendData;
 
 interface SignupForm {
   username?: string;
@@ -57,6 +60,26 @@ useHead(useSeo("Signup", null, route, null));
     <template #header>
       <h1>Sign up</h1>
     </template>
+
+    <div v-if="!done && backendData.security.oauthProviders.length > 0" class="mb-2">
+      Either login using an OAuth Provider
+      <div class="flex gap-2 mt-2">
+        <Button
+          v-for="provider in backendData.security.oauthProviders"
+          :key="provider"
+          :disabled="loading"
+          :href="'/api/internal/oauth/' + provider + '/login?mode=signup&returnUrl=/'"
+        >
+          <template v-if="provider === 'github'">
+            <IconMdiGitHub class="mr-1" />
+            Login with GitHub
+          </template>
+          <template v-else> Login with {{ provider }} </template>
+        </Button>
+      </div>
+      <hr class="mt-3 mb-2" />
+      or create a new account below
+    </div>
 
     <form v-if="!done" class="flex flex-col gap-2">
       <InputText v-model="form.username" label="Username" name="username" autocomplete="username" :rules="[required()]" />

--- a/frontend/src/store/auth.ts
+++ b/frontend/src/store/auth.ts
@@ -12,7 +12,6 @@ export const useAuthStore = defineStore("auth", () => {
   const routePermissionsUser = ref<string | null>(null);
   const routePermissionsProject = ref<string | null>(null);
   const invalidated = ref<boolean>(false);
-  const privileged = ref<boolean>(false);
 
   authLog("create authStore");
 
@@ -22,5 +21,5 @@ export const useAuthStore = defineStore("auth", () => {
     routePermissionsProject.value = routePermsProject;
   }
 
-  return { token, authenticated, user, routePermissions, invalidated, setRoutePerms, routePermissionsUser, routePermissionsProject, aal, privileged };
+  return { token, authenticated, user, routePermissions, invalidated, setRoutePerms, routePermissionsUser, routePermissionsProject, aal };
 });

--- a/frontend/src/types/api.d.ts
+++ b/frontend/src/types/api.d.ts
@@ -71,6 +71,7 @@ declare module "hangar-api" {
 
   interface Security {
     safeDownloadHosts: string[];
+    oauthProviders: string[];
   }
 
   interface BackendData {

--- a/frontend/src/types/generated/icons.d.ts
+++ b/frontend/src/types/generated/icons.d.ts
@@ -10,7 +10,6 @@ declare module "vue" {
     IconMdiAccountPlus: typeof import("~icons/mdi/account-plus")["default"];
     IconMdiAlert: typeof import("~icons/mdi/alert")["default"];
     IconMdiAlertBox: typeof import("~icons/mdi/alert-box")["default"];
-    IconMdiAlertDecagram: typeof import("~icons/mdi/alert-decagram")["default"];
     IconMdiAlertOutline: typeof import("~icons/mdi/alert-outline")["default"];
     IconMdiBell: typeof import("~icons/mdi/bell")["default"];
     IconMdiBellBadge: typeof import("~icons/mdi/bell-badge")["default"];
@@ -30,6 +29,7 @@ declare module "vue" {
     IconMdiClipboardOutline: typeof import("~icons/mdi/clipboard-outline")["default"];
     IconMdiClose: typeof import("~icons/mdi/close")["default"];
     IconMdiCloseCircle: typeof import("~icons/mdi/close-circle")["default"];
+    IconMdiCloudSearch: typeof import("~icons/mdi/cloud-search")["default"];
     IconMdiCodeBracesBox: typeof import("~icons/mdi/code-braces-box")["default"];
     IconMdiCogTransfer: typeof import("~icons/mdi/cog-transfer")["default"];
     IconMdiContentCopy: typeof import("~icons/mdi/content-copy")["default"];
@@ -42,8 +42,8 @@ declare module "vue" {
     IconMdiEarth: typeof import("~icons/mdi/earth")["default"];
     IconMdiEye: typeof import("~icons/mdi/eye")["default"];
     IconMdiEyeOff: typeof import("~icons/mdi/eye-off")["default"];
-    IconMdiFileDocument: typeof import("~icons/mdi/file-document")["default"];
     IconMdiFlag: typeof import("~icons/mdi/flag")["default"];
+    IconMdiFolderPlusOutline: typeof import("~icons/mdi/folder-plus-outline")["default"];
     IconMdiFormatListNumbered: typeof import("~icons/mdi/format-list-numbered")["default"];
     IconMdiGamepadRoundLeft: typeof import("~icons/mdi/gamepad-round-left")["default"];
     IconMdiHelpCircleOutline: typeof import("~icons/mdi/help-circle-outline")["default"];
@@ -52,17 +52,15 @@ declare module "vue" {
     IconMdiInformation: typeof import("~icons/mdi/information")["default"];
     IconMdiKeyOutline: typeof import("~icons/mdi/key-outline")["default"];
     IconMdiLeaf: typeof import("~icons/mdi/leaf")["default"];
-    IconMdiListStatus: typeof import("~icons/mdi/list-status")["default"];
+    IconMdiLicense: typeof import("~icons/mdi/license")["default"];
+    IconMdiLink: typeof import("~icons/mdi/link")["default"];
     IconMdiLockOpenOutline: typeof import("~icons/mdi/lock-open-outline")["default"];
     IconMdiLockOutline: typeof import("~icons/mdi/lock-outline")["default"];
     IconMdiMenu: typeof import("~icons/mdi/menu")["default"];
     IconMdiMenuDown: typeof import("~icons/mdi/menu-down")["default"];
     IconMdiOpenInNew: typeof import("~icons/mdi/open-in-new")["default"];
     IconMdiPencil: typeof import("~icons/mdi/pencil")["default"];
-    IconMdiPin: typeof import("~icons/mdi/pin")["default"];
-    IconMdiPinOff: typeof import("~icons/mdi/pin-off")["default"];
     IconMdiPinOutline: typeof import("~icons/mdi/pin-outline")["default"];
-    IconMdiPlay: typeof import("~icons/mdi/play")["default"];
     IconMdiPlus: typeof import("~icons/mdi/plus")["default"];
     IconMdiProgressQuestion: typeof import("~icons/mdi/progress-question")["default"];
     IconMdiPuzzleOutline: typeof import("~icons/mdi/puzzle-outline")["default"];

--- a/frontend/src/types/internal/users.d.ts
+++ b/frontend/src/types/internal/users.d.ts
@@ -87,6 +87,7 @@ declare module "hangar-internal" {
 
   interface AuthSettings {
     authenticators: { addedAt: string; displayName: string; id: string }[];
+    oAuthCredentials: { id: string; name: string; provider: string }[];
     hasBackupCodes: boolean;
     hasTotp: boolean;
     emailConfirmed: boolean;

--- a/frontend/src/types/internal/users.d.ts
+++ b/frontend/src/types/internal/users.d.ts
@@ -92,6 +92,7 @@ declare module "hangar-internal" {
     hasTotp: boolean;
     emailConfirmed: boolean;
     emailPending: boolean;
+    hasPassword: boolean;
   }
 
   interface LoginResponse {

--- a/frontend/src/types/internal/users.d.ts
+++ b/frontend/src/types/internal/users.d.ts
@@ -87,7 +87,7 @@ declare module "hangar-internal" {
 
   interface AuthSettings {
     authenticators: { addedAt: string; displayName: string; id: string }[];
-    oAuthCredentials: { id: string; name: string; provider: string }[];
+    oauthConnections: { id: string; name: string; provider: string }[];
     hasBackupCodes: boolean;
     hasTotp: boolean;
     emailConfirmed: boolean;


### PR DESCRIPTION
closes #1136

- [x] test signup
- [x] signup needs a way to override username and email
- [ ] error handling (if one of the oauthcontrollers return an exception, display them nicely in some UI)
- [ ] audit the code
- [x] make oauth providers configurable
- [x] look into adding more providers (msft, google, apple?)
- [x] look at why sudo is broken
~~- [ ] lift the user_id credentials_type uniqueness limitation~~
- [x] properly allow multiple webauthn creds
- [x] configure secrets