### PR TITLE
Extract PinnedStatus enum from VersionCompact to prevent invalid openapi paths

### DIFF
--- a/backend/src/main/java/io/papermc/hangar/model/api/project/version/PinnedStatus.java
+++ b/backend/src/main/java/io/papermc/hangar/model/api/project/version/PinnedStatus.java
@@ -1,0 +1,12 @@
+package io.papermc.hangar.model.api.project.version;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import org.jdbi.v3.core.enums.EnumByName;
+
+@EnumByName
+@JsonFormat(shape = JsonFormat.Shape.STRING)
+public enum PinnedStatus {
+    NONE,
+    VERSION,
+    CHANNEL
+}

--- a/backend/src/main/java/io/papermc/hangar/model/api/project/version/VersionCompact.java
+++ b/backend/src/main/java/io/papermc/hangar/model/api/project/version/VersionCompact.java
@@ -1,6 +1,5 @@
 package io.papermc.hangar.model.api.project.version;
 
-import com.fasterxml.jackson.annotation.JsonFormat;
 import io.papermc.hangar.model.Model;
 import io.papermc.hangar.model.Named;
 import io.papermc.hangar.model.Visible;
@@ -11,7 +10,6 @@ import io.papermc.hangar.model.common.projects.Visibility;
 import java.time.OffsetDateTime;
 import java.util.EnumMap;
 import java.util.Map;
-import org.jdbi.v3.core.enums.EnumByName;
 import org.jdbi.v3.core.enums.EnumByOrdinal;
 import org.jdbi.v3.core.mapper.Nested;
 import org.jdbi.v3.core.mapper.reflect.ColumnName;
@@ -76,13 +74,5 @@ public class VersionCompact extends Model implements Named, Visible {
 
     public PinnedStatus getPinnedStatus() {
         return this.pinnedStatus;
-    }
-
-    @EnumByName
-    @JsonFormat(shape = JsonFormat.Shape.STRING)
-    public enum PinnedStatus {
-        NONE,
-        VERSION,
-        CHANNEL
     }
 }

--- a/backend/src/main/java/io/papermc/hangar/model/internal/versions/HangarVersion.java
+++ b/backend/src/main/java/io/papermc/hangar/model/internal/versions/HangarVersion.java
@@ -3,6 +3,7 @@ package io.papermc.hangar.model.internal.versions;
 import io.papermc.hangar.config.jackson.RequiresPermission;
 import io.papermc.hangar.model.Identified;
 import io.papermc.hangar.model.api.project.ProjectChannel;
+import io.papermc.hangar.model.api.project.version.PinnedStatus;
 import io.papermc.hangar.model.api.project.version.Version;
 import io.papermc.hangar.model.api.project.version.VersionStats;
 import io.papermc.hangar.model.common.NamedPermission;


### PR DESCRIPTION
The current API spec has a schema with the name "io.papermc.hangar.model.api.project.version.VersionCompact$PinnedStatus".
This is not allowed in the OpenAPI spec and causes the Swagger Editor and OpenAPI Generator to throw errors.

This PR extracts this inner class to its own file to prevent this issue.