### PR TITLE
Verify project visibility when using slugs

### DIFF
--- a/backend/src/main/java/io/papermc/hangar/service/internal/projects/ProjectService.java
+++ b/backend/src/main/java/io/papermc/hangar/service/internal/projects/ProjectService.java
@@ -101,7 +101,7 @@ public class ProjectService extends HangarComponent {
     }
 
     public ProjectTable getProjectTable(final String slug) {
-        return this.projectsDAO.getBySlug(slug);
+        return this.getProjectTable(slug, this.projectsDAO::getBySlug);
     }
 
     public List<ProjectTable> getProjectTables(final long userId) {


### PR DESCRIPTION
As mentioned on Discord, it appears that the visibility isn't checked for projects when a slug is passed.
This PR changes `ProjectService.getProjectTable(String)` to call the same function as `getProjectTables(long)`.