### PR TITLE
Add missing VisibilityRequired annotations

### DIFF
--- a/backend/src/main/java/io/papermc/hangar/controller/api/v1/VersionsController.java
+++ b/backend/src/main/java/io/papermc/hangar/controller/api/v1/VersionsController.java
@@ -108,7 +108,7 @@ public class VersionsController implements IVersionsController {
 
     @Override
     @RateLimit(overdraft = 10, refillTokens = 2)
-    @VisibilityRequired(type = VisibilityRequired.Type.VERSION, args = "{#project, #version, #platform}")
+    @VisibilityRequired(type = VisibilityRequired.Type.VERSION, args = "{#project, #version}")
     public ResponseEntity<?> downloadVersion(final ProjectTable project, final ProjectVersionTable version, final Platform platform, final HttpServletResponse response) {
         return this.downloadService.downloadVersion(project, version, platform);
     }

--- a/backend/src/main/java/io/papermc/hangar/controller/api/v1/VersionsController.java
+++ b/backend/src/main/java/io/papermc/hangar/controller/api/v1/VersionsController.java
@@ -64,7 +64,7 @@ public class VersionsController implements IVersionsController {
     }
 
     @Override
-    @VisibilityRequired(type = VisibilityRequired.Type.PROJECT, args = "{#project}")
+    @VisibilityRequired(type = VisibilityRequired.Type.VERSION, args = "{#version}")
     public Version getVersion(final ProjectTable project, final ProjectVersionTable version) {
         return this.versionsApiService.getVersion(project, version);
     }

--- a/backend/src/main/java/io/papermc/hangar/controller/api/v1/VersionsController.java
+++ b/backend/src/main/java/io/papermc/hangar/controller/api/v1/VersionsController.java
@@ -97,11 +97,13 @@ public class VersionsController implements IVersionsController {
     }
 
     @Override
+    @VisibilityRequired(type = VisibilityRequired.Type.VERSION, args = "{#version}")
     public Map<String, VersionStats> getVersionStats(final ProjectTable project, final ProjectVersionTable version, final @NotNull OffsetDateTime fromDate, final @NotNull OffsetDateTime toDate) {
         return this.versionsApiService.getVersionStats(version, fromDate, toDate);
     }
 
     @Override
+    @VisibilityRequired(type = VisibilityRequired.Type.VERSION, args = "{#version}")
     public Map<String, VersionStats> getVersionStatsById(final ProjectVersionTable version, final @NotNull OffsetDateTime fromDate, final @NotNull OffsetDateTime toDate) {
         return this.versionsApiService.getVersionStats(version, fromDate, toDate);
     }

--- a/backend/src/main/java/io/papermc/hangar/controller/internal/VersionController.java
+++ b/backend/src/main/java/io/papermc/hangar/controller/internal/VersionController.java
@@ -185,8 +185,7 @@ public class VersionController extends HangarComponent {
 
     @ErrorRedirect
     @RateLimit(overdraft = 5, refillTokens = 1, refillSeconds = 20)
-    @VisibilityRequired(type = VisibilityRequired.Type.VERSION, args = "{#project, #version, #platform}")
-    // TODO is platform needed in the visibility check? it's not used in the VisibilityRequiredVoter
+    @VisibilityRequired(type = VisibilityRequired.Type.VERSION, args = "{#project, #version}")
     @GetMapping(path = "/version/{project}/versions/{version}/{platform}/download", produces = MediaType.APPLICATION_OCTET_STREAM_VALUE)
     public ResponseEntity<?> download(@PathVariable final ProjectTable project, @PathVariable final ProjectVersionTable version, @PathVariable final Platform platform) {
         return this.downloadService.downloadVersion(project, version, platform);

--- a/backend/src/main/java/io/papermc/hangar/controller/internal/projects/ProjectPageController.java
+++ b/backend/src/main/java/io/papermc/hangar/controller/internal/projects/ProjectPageController.java
@@ -75,6 +75,7 @@ public class ProjectPageController extends HangarComponent {
 
     @Unlocked
     @RateLimit(overdraft = 5, refillTokens = 1, refillSeconds = 20)
+    @VisibilityRequired(type = VisibilityRequired.Type.PROJECT, args = "{#project}")
     @GetMapping("/list/{projectId}")
     @ResponseStatus(HttpStatus.OK)
     public ResponseEntity<Collection<HangarProjectPage>> listProjectPages(@PathVariable final long projectId) {

--- a/backend/src/main/java/io/papermc/hangar/security/annotations/visibility/VisibilityRequired.java
+++ b/backend/src/main/java/io/papermc/hangar/security/annotations/visibility/VisibilityRequired.java
@@ -32,7 +32,7 @@ public @interface VisibilityRequired {
 
     enum Type {
         PROJECT(1),
-        VERSION(1, 3);
+        VERSION(1, 2);
 
         private final Set<Integer> argCount;
 

--- a/backend/src/main/java/io/papermc/hangar/security/annotations/visibility/VisibilityRequiredVoter.java
+++ b/backend/src/main/java/io/papermc/hangar/security/annotations/visibility/VisibilityRequiredVoter.java
@@ -58,15 +58,15 @@ public class VisibilityRequiredVoter extends HangarDecisionVoter<VisibilityRequi
                 return ACCESS_DENIED;
             case VERSION:
                 if (arguments.length == 1) {
-                    if (arguments[0] instanceof ProjectVersionTable projectVersionTable) {
+                    if (arguments[0] instanceof final ProjectVersionTable projectVersionTable) {
                         if (this.projectVersionVisibilityService.checkVisibility(projectVersionTable) != null) {
                             return ACCESS_GRANTED;
                         }
                     } else if (this.versionService.getProjectVersionTable((long) arguments[0]) != null) {
                         return ACCESS_GRANTED;
                     }
-                } else if (arguments.length == 3) {
-                    if (arguments[1] instanceof ProjectVersionTable projectVersionTable) {
+                } else if (arguments.length == 2) {
+                    if (arguments[1] instanceof final ProjectVersionTable projectVersionTable) {
                         if (this.projectVersionVisibilityService.checkVisibility(projectVersionTable) != null) {
                             return ACCESS_GRANTED;
                         }


### PR DESCRIPTION
This PR adds the VisibilityRequired annotation to places where it was previously missing. It also removes the platform argument, as that has never been used and isn't available in every endpoint.

I also added the annotation to `getVersionStats` of the public API. I'm not entirely sure whether this endpoint is supposed to require a permission, like the project stats endpoint.