### PR TITLE
Use deterministic ordering for springdoc

### DIFF
--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -46,8 +46,9 @@ spring:
   jmx:
     enabled: false
 
+springdoc:
+  writer-with-order-by-keys: true
 # Enable this if you want to regenerate the frontend types
-#springdoc:
 #  use-fqn: true
 
 management:


### PR DESCRIPTION
Many parts of the API docs (e.g. api responses) are ordered seemingly randomly every time a change occurs.
That results in changes to generated API clients, which reuse the existing order from the API spec.

This PR configures springdoc to order these keys alphabetically to prevent that.