### PR TITLE
Accept project/organization IDs in permission endpoints

### DIFF
--- a/backend/src/main/java/io/papermc/hangar/controller/api/v1/PermissionsController.java
+++ b/backend/src/main/java/io/papermc/hangar/controller/api/v1/PermissionsController.java
@@ -8,9 +8,14 @@ import io.papermc.hangar.model.api.permissions.UserPermissions;
 import io.papermc.hangar.model.common.NamedPermission;
 import io.papermc.hangar.model.common.Permission;
 import io.papermc.hangar.model.common.PermissionType;
+import io.papermc.hangar.model.db.OrganizationTable;
+import io.papermc.hangar.model.db.projects.ProjectTable;
 import io.papermc.hangar.security.annotations.Anyone;
 import io.papermc.hangar.security.annotations.ratelimit.RateLimit;
 import io.papermc.hangar.service.PermissionService;
+import io.papermc.hangar.service.internal.organizations.OrganizationService;
+import io.papermc.hangar.service.internal.projects.ProjectService;
+import io.papermc.hangar.util.StringUtils;
 import java.util.Collection;
 import java.util.Set;
 import java.util.function.BiPredicate;
@@ -26,50 +31,81 @@ import org.springframework.stereotype.Controller;
 @RateLimit(path = "apipermissions", refillTokens = 100, greedy = true)
 public class PermissionsController extends HangarComponent implements IPermissionsController {
 
+    private final OrganizationService organizationService;
+    private final ProjectService projectService;
     private final PermissionService permissionService;
 
     @Autowired
-    public PermissionsController(final PermissionService permissionService) {
+    public PermissionsController(final OrganizationService organizationService, final ProjectService projectService, final PermissionService permissionService) {
+        this.organizationService = organizationService;
+        this.projectService = projectService;
         this.permissionService = permissionService;
     }
 
     @Override
-    public ResponseEntity<PermissionCheck> hasAllPermissions(final Set<NamedPermission> permissions, final String slug, final String organization) {
-        return this.has(permissions, slug, organization, (namedPerms, perm) -> namedPerms.stream().allMatch(p -> perm.has(p.getPermission())));
+    public ResponseEntity<PermissionCheck> hasAllPermissions(final Set<NamedPermission> permissions, final String project, final String organization) {
+        return this.has(permissions, project, organization, (namedPerms, perm) -> namedPerms.stream().allMatch(p -> perm.has(p.getPermission())));
     }
 
     @Override
-    public ResponseEntity<PermissionCheck> hasAny(final Set<NamedPermission> permissions, final String slug, final String organization) {
-        return this.has(permissions, slug, organization, (namedPerms, perm) -> namedPerms.stream().anyMatch(p -> perm.has(p.getPermission())));
+    public ResponseEntity<PermissionCheck> hasAny(final Set<NamedPermission> permissions, final String project, final String organization) {
+        return this.has(permissions, project, organization, (namedPerms, perm) -> namedPerms.stream().anyMatch(p -> perm.has(p.getPermission())));
     }
 
     @Override
-    public ResponseEntity<UserPermissions> showPermissions(final String slug, final String organization) {
-        final Pair<PermissionType, Permission> scopedPerms = this.getPermissionsInScope(slug, organization);
+    public ResponseEntity<UserPermissions> showPermissions(final String project, final String organization) {
+        final Pair<PermissionType, Permission> scopedPerms = this.getPermissionsInScope(project, organization);
         return ResponseEntity.ok(new UserPermissions(scopedPerms.getLeft(), scopedPerms.getRight().toBinString(), scopedPerms.getRight().toNamed()));
     }
 
-    private Pair<PermissionType, Permission> getPermissionsInScope(final String slug, final String organization) {
-        if (slug != null && organization == null) { // author & slug
-            Permission perms = this.permissionService.getProjectPermissions(this.getHangarUserId(), slug);
-            perms = this.getHangarPrincipal().getPossiblePermissions().intersect(perms);
-            return new ImmutablePair<>(PermissionType.PROJECT, perms);
-        } else if (slug == null && organization == null) { // current user (I don't think there's a need to see other user's global permissions)
-            Permission perms = this.permissionService.getGlobalPermissions(this.getHangarUserId());
-            perms = this.getHangarPrincipal().getPossiblePermissions().intersect(perms);
-            return new ImmutablePair<>(PermissionType.GLOBAL, perms);
-        } else if (slug == null) { // just org
-            Permission perms = this.permissionService.getOrganizationPermissions(this.getHangarUserId(), organization);
-            perms = this.getHangarPrincipal().getPossiblePermissions().intersect(perms);
-            return new ImmutablePair<>(PermissionType.ORGANIZATION, perms);
-        } else {
-            // unreachable
-            throw new HangarApiException(HttpStatus.BAD_REQUEST, "Incorrect request parameters");
+    private Pair<PermissionType, Permission> getPermissionsInScope(final String project, final String organization) {
+        if (project != null && organization != null) {
+            throw new HangarApiException(HttpStatus.BAD_REQUEST, "Specifying both project and organization is not allowed");
         }
+
+        if (project != null) {
+            ProjectTable projectTable = null;
+            if (StringUtils.isLong(project)) {
+                projectTable = this.projectService.getProjectTable(Long.parseLong(project));
+            }
+
+            if (projectTable == null) {
+                projectTable = this.projectService.getProjectTable(project);
+            }
+
+            if (projectTable == null) {
+                throw new HangarApiException(HttpStatus.NOT_FOUND, "Project not found");
+            }
+
+            final Permission perms = this.permissionService.getProjectPermissions(this.getHangarUserId(), projectTable.getId());
+            return new ImmutablePair<>(PermissionType.PROJECT, perms);
+        }
+
+        if (organization != null) {
+            OrganizationTable organizationTable = null;
+            if (StringUtils.isLong(organization)) {
+                organizationTable = this.organizationService.getOrganizationTable(Long.parseLong(organization));
+            }
+
+            if (organizationTable == null) {
+                organizationTable = this.organizationService.getOrganizationTable(organization);
+            }
+
+            if (organizationTable == null) {
+                throw new HangarApiException(HttpStatus.NOT_FOUND, "Organization not found");
+            }
+
+            final Permission perms = this.permissionService.getOrganizationPermissions(this.getHangarUserId(), organizationTable.getId());
+            return new ImmutablePair<>(PermissionType.ORGANIZATION, perms);
+        }
+
+        Permission perms = this.permissionService.getGlobalPermissions(this.getHangarUserId());
+        perms = this.getHangarPrincipal().getPossiblePermissions().intersect(perms);
+        return new ImmutablePair<>(PermissionType.GLOBAL, perms);
     }
 
-    private ResponseEntity<PermissionCheck> has(final Collection<NamedPermission> perms, final String slug, final String organization, final BiPredicate<Collection<NamedPermission>, Permission> check) {
-        final Pair<PermissionType, Permission> scopedPerms = this.getPermissionsInScope(slug, organization);
+    private ResponseEntity<PermissionCheck> has(final Collection<NamedPermission> perms, final String project, final String organization, final BiPredicate<Collection<NamedPermission>, Permission> check) {
+        final Pair<PermissionType, Permission> scopedPerms = this.getPermissionsInScope(project, organization);
         return ResponseEntity.ok(new PermissionCheck(scopedPerms.getLeft(), check.test(perms, scopedPerms.getRight())));
     }
 }

--- a/backend/src/main/java/io/papermc/hangar/controller/api/v1/interfaces/IPermissionsController.java
+++ b/backend/src/main/java/io/papermc/hangar/controller/api/v1/interfaces/IPermissionsController.java
@@ -34,11 +34,34 @@ public interface IPermissionsController {
         @ApiResponse(responseCode = "400", description = "Bad Request"),
         @ApiResponse(responseCode = "401", description = "Api session missing, invalid or expired")
     })
-    @GetMapping("/permissions/hasAll")
-    ResponseEntity<PermissionCheck> hasAllPermissions(@Parameter(description = "The permissions to check", required = true) @RequestParam @Size(max = 50) Set<NamedPermission> permissions,
-                                                      @Parameter(description = "The project slug of the project to check permissions in. Must not be used together with `organizationName`") @RequestParam(required = false) String slug,
-                                                      @Parameter(description = "The organization to check permissions in. Must not be used together with `projectOwner` and `projectSlug`") @RequestParam(required = false) String organization
+    @GetMapping(value = "/permissions/hasAll", params = "!slug")
+    ResponseEntity<PermissionCheck> hasAllPermissions(
+        @Parameter(description = "The permissions to check", required = true) @RequestParam @Size(max = 50) Set<NamedPermission> permissions,
+        @Parameter(description = "The id or slug of the project to check permissions in. Must not be used together with `organization`") @RequestParam(required = false) String project,
+        @Parameter(description = "The id or name of the organization to check permissions in. Must not be used together with `project`") @RequestParam(required = false) String organization
     );
+
+    @Operation(
+        summary = "Checks whether you have all the provided permissions",
+        operationId = "hasAllLegacy",
+        description = "Checks whether you have all the provided permissions in the given context",
+        security = @SecurityRequirement(name = "HangarAuth"),
+        tags = "Permissions"
+    )
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "Ok"),
+        @ApiResponse(responseCode = "400", description = "Bad Request"),
+        @ApiResponse(responseCode = "401", description = "Api session missing, invalid or expired")
+    })
+    @GetMapping(value = "/permissions/hasAll", params = "slug")
+    default ResponseEntity<PermissionCheck> hasAllPermissionsLegacy(
+        @Parameter(description = "The permissions to check", required = true) @RequestParam final @Size(max = 50) Set<NamedPermission> permissions,
+        @Deprecated @Parameter(description = "Deprecated alias for `project`") @RequestParam(required = false) final String slug,
+        @Parameter(description = "The id or name of the organization to check permissions in. Must not be used together with `slug`") @RequestParam(required = false) final String organization
+    ) {
+        return this.hasAllPermissions(permissions, slug, organization);
+    }
+
 
     @Operation(
         summary = "Checks whether you have at least one of the provided permissions",
@@ -52,11 +75,33 @@ public interface IPermissionsController {
         @ApiResponse(responseCode = "400", description = "Bad Request"),
         @ApiResponse(responseCode = "401", description = "Api session missing, invalid or expired")
     })
-    @GetMapping("/permissions/hasAny")
-    ResponseEntity<PermissionCheck> hasAny(@Parameter(description = "The permissions to check", required = true) @RequestParam Set<NamedPermission> permissions,
-                                           @Parameter(description = "The slug of the project to check permissions in. Must not be used together with `organization`") @RequestParam(required = false) String slug,
-                                           @Parameter(description = "The organization to check permissions in. Must not be used together with `slug`") @RequestParam(required = false) String organization
+    @GetMapping(value = "/permissions/hasAny", params = "!slug")
+    ResponseEntity<PermissionCheck> hasAny(
+        @Parameter(description = "The permissions to check", required = true) @RequestParam Set<NamedPermission> permissions,
+        @Parameter(description = "The id or slug of the project to check permissions in. Must not be used together with `organization`") @RequestParam(required = false) String project,
+        @Parameter(description = "The id or name of the organization to check permissions in. Must not be used together with `project`") @RequestParam(required = false) String organization
     );
+
+    @Operation(
+        summary = "Checks whether you have at least one of the provided permissions",
+        operationId = "hasAnyLegacy",
+        description = "Checks whether you have at least one of the provided permissions in the given context",
+        security = @SecurityRequirement(name = "HangarAuth"),
+        tags = "Permissions"
+    )
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "Ok"),
+        @ApiResponse(responseCode = "400", description = "Bad Request"),
+        @ApiResponse(responseCode = "401", description = "Api session missing, invalid or expired")
+    })
+    @GetMapping(value = "/permissions/hasAny", params = "slug")
+    default ResponseEntity<PermissionCheck> hasAnyLegacy(
+        @Parameter(description = "The permissions to check", required = true) @RequestParam final Set<NamedPermission> permissions,
+        @Deprecated @Parameter(description = "Deprecated alias for `project`") @RequestParam(required = false) final String slug,
+        @Parameter(description = "The id or name of the organization to check permissions in. Must not be used together with `project`") @RequestParam(required = false) final String organization
+    ) {
+        return this.hasAny(permissions, slug, organization);
+    }
 
     @Operation(
         summary = "Returns your permissions",
@@ -70,10 +115,29 @@ public interface IPermissionsController {
         @ApiResponse(responseCode = "400", description = "Bad Request"),
         @ApiResponse(responseCode = "401", description = "Api session missing, invalid or expired")
     })
-    @GetMapping(value = "/permissions",
-        produces = MediaType.APPLICATION_JSON_VALUE)
+    @GetMapping(value = "/permissions", params = "!slug", produces = MediaType.APPLICATION_JSON_VALUE)
     ResponseEntity<UserPermissions> showPermissions(
-        @Parameter(description = "The slug of the project get the permissions for. Must not be used together with `organization`") @RequestParam(required = false) String slug,
-        @Parameter(description = "The organization to check permissions in. Must not be used together with `slug`") @RequestParam(required = false) String organization
+        @Parameter(description = "The id or slug of the project to check permissions in. Must not be used together with `organization`") @RequestParam(required = false) String project,
+        @Parameter(description = "The id or name of the organization to check permissions in. Must not be used together with `project`") @RequestParam(required = false) String organization
     );
+
+    @Operation(
+        summary = "Returns your permissions",
+        operationId = "showPermissionsLegacy",
+        description = "Returns a list of permissions you have in the given context",
+        security = @SecurityRequirement(name = "HangarAuth"),
+        tags = "Permissions"
+    )
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "Ok"),
+        @ApiResponse(responseCode = "400", description = "Bad Request"),
+        @ApiResponse(responseCode = "401", description = "Api session missing, invalid or expired")
+    })
+    @GetMapping(value = "/permissions", params = "slug", produces = MediaType.APPLICATION_JSON_VALUE)
+    default ResponseEntity<UserPermissions> showPermissionsLegacy(
+        @Deprecated @Parameter(description = "Deprecated alias for `project`") @RequestParam(required = false) final String slug,
+        @Parameter(description = "The id or name of the organization to check permissions in. Must not be used together with `project`") @RequestParam(required = false) final String organization
+    ) {
+        return this.showPermissions(slug, organization);
+    }
 }


### PR DESCRIPTION
This PR adds support for project/organization IDs in the permission endpoints. I missed this in the original PR for IDs in the API.

The endpoints now also throw a 404 if a project/org wasn't found, instead of returning default permissions.
I'm not 100% sure if this behavior is desired, and I can change it back, but that would either be slightly more complicated or a bit hacky (passing Long.MAX_VALUE as an invalid project/org ID).