### PR TITLE
Replace all Table parameters with strings in the OpenAPI schema

### DIFF
--- a/backend/src/main/java/io/papermc/hangar/config/SwaggerConfig.java
+++ b/backend/src/main/java/io/papermc/hangar/config/SwaggerConfig.java
@@ -8,6 +8,8 @@ import io.papermc.hangar.controller.extras.pagination.annotations.ApplicableSort
 import io.papermc.hangar.exceptions.HangarApiException;
 import io.papermc.hangar.exceptions.MethodArgumentNotValidExceptionSerializer;
 import io.papermc.hangar.exceptions.MultiHangarApiException;
+import io.papermc.hangar.model.db.OrganizationTable;
+import io.papermc.hangar.model.db.Table;
 import io.papermc.hangar.model.db.UserTable;
 import io.papermc.hangar.model.db.projects.ProjectTable;
 import io.papermc.hangar.model.db.versions.ProjectVersionTable;
@@ -170,7 +172,7 @@ public class SwaggerConfig {
     public static class SlugOrIdCustomizer implements ParameterCustomizer {
         @Override
         public Parameter customize(final Parameter parameter, final MethodParameter methodParameter) {
-            if (Set.of(ProjectTable.class, ProjectVersionTable.class, UserTable.class).contains(methodParameter.getParameterType())) {
+            if (Table.class.isAssignableFrom(methodParameter.getParameterType())) {
                 return parameter.schema(new StringSchema());
             }
             return parameter;

--- a/backend/src/main/java/io/papermc/hangar/config/SwaggerConfig.java
+++ b/backend/src/main/java/io/papermc/hangar/config/SwaggerConfig.java
@@ -8,11 +8,7 @@ import io.papermc.hangar.controller.extras.pagination.annotations.ApplicableSort
 import io.papermc.hangar.exceptions.HangarApiException;
 import io.papermc.hangar.exceptions.MethodArgumentNotValidExceptionSerializer;
 import io.papermc.hangar.exceptions.MultiHangarApiException;
-import io.papermc.hangar.model.db.OrganizationTable;
 import io.papermc.hangar.model.db.Table;
-import io.papermc.hangar.model.db.UserTable;
-import io.papermc.hangar.model.db.projects.ProjectTable;
-import io.papermc.hangar.model.db.versions.ProjectVersionTable;
 import io.swagger.v3.core.converter.ModelConverters;
 import io.swagger.v3.oas.models.Operation;
 import io.swagger.v3.oas.models.info.Info;


### PR DESCRIPTION
Since table parameters are resolved from the slug or ID, they should be considered a string in the API documentation.
This was already applied for the Project, Version and User tables, but the OriganizationTable (used in the permission endpoints) was missing.

I replaced the list of tables with a subclass check, which should prevent this issue from occurring again with any table parameters.