### PR TITLE
Downgrade springdoc to 2.7.0

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -32,7 +32,7 @@
 
         <!-- dependencies -->
         <sentry.version>7.20.0</sentry.version>
-        <springdoc.version>2.8.1</springdoc.version>
+        <springdoc.version>2.7.0</springdoc.version>
         <jsitemapgenerator.version>4.5</jsitemapgenerator.version>
         <org-json.version>20250107</org-json.version>
         <bucket4j.version>8.14.0</bucket4j.version>


### PR DESCRIPTION
Springdoc 2.8.1 does not parse `@Schema` annotations as it intended: https://github.com/springdoc/springdoc-openapi/issues/2851
This can be seen in the `/pages/main/{project}` endpoint where the return type for the 200 response has the `@Schema(type = "string")` annotation, but that type does not show up in the resulting OpenAPI spec.

The issue has apparently been solved in 2.8.3, but when I try to run hangar locally with this version it crashes: https://pastes.dev/mfOZD1TuO6