### PR TITLE
Mark VersionUpload required fields in OpenAPI schema

### DIFF
--- a/backend/src/main/java/io/papermc/hangar/model/internal/versions/VersionUpload.java
+++ b/backend/src/main/java/io/papermc/hangar/model/internal/versions/VersionUpload.java
@@ -16,22 +16,23 @@ public class VersionUpload {
 
     // @el(root: String)
     @NotBlank(message = "version.new.error.invalidVersionString")
-    @Schema(description = "Version string of the version to be published", example = "1.0.0-SNAPSHOT+1")
+    @Schema(description = "Version string of the version to be published", example = "1.0.0-SNAPSHOT+1", requiredMode = Schema.RequiredMode.REQUIRED)
     private final @Validate(SpEL = "@validate.regex(#root, @'hangar-io.papermc.hangar.config.hangar.HangarConfig'.projects.versionNameRegex)", message = "version.new.error.invalidVersionString") String version;
     @Schema(description = "Map of each platform's plugin dependencies")
     private final Map<Platform, Set<@Valid PluginDependency>> pluginDependencies;
     @Size(min = 1, max = 3, message = "version.new.error.invalidNumOfPlatforms")
-    @Schema(description = "Map of platforms and their versions this version runs on", example = "{PAPER: [\"1.12\", \"1.16-1.18.2\", \"1.20.x\"]}")
+    @Schema(description = "Map of platforms and their versions this version runs on", example = "{PAPER: [\"1.12\", \"1.16-1.18.2\", \"1.20.x\"]}", requiredMode = Schema.RequiredMode.REQUIRED)
     private final Map<Platform, @Size(min = 1, message = "version.edit.error.noPlatformVersions") SortedSet<@NotBlank(message = "version.new.error.invalidPlatformVersion") String>> platformDependencies;
 
     // @el(root: String)
     private final @Validate(SpEL = "@validate.max(#root, @'hangar-io.papermc.hangar.config.hangar.HangarConfig'.pages.maxLen)", message = "page.new.error.maxLength") String description;
-    @Size(min = 1, max = 3, message = "version.new.error.invalidNumOfPlatforms")
+    @Size(min = 1, max = 3, message = "version.new.error.invalidNumberOfFiles")
+    @Schema(description = "List of jars/external links that make up this version", requiredMode = Schema.RequiredMode.REQUIRED)
     private final List<@Valid MultipartFileOrUrl> files;
 
     // @el(root: String)
     @NotBlank(message = "version.new.error.channel.noName")
-    @Schema(description = "Channel of the version to be published under", example = "Release")
+    @Schema(description = "Channel of the version to be published under", example = "Release", requiredMode = Schema.RequiredMode.REQUIRED)
     private final @Validate(SpEL = "@validate.regex(#root, @'hangar-io.papermc.hangar.config.hangar.HangarConfig'.channels.nameRegex)", message = "channel.modal.error.invalidName") String channel;
 
     @JsonCreator(mode = JsonCreator.Mode.PROPERTIES)

--- a/frontend/app/i18n/locales/en.json
+++ b/frontend/app/i18n/locales/en.json
@@ -523,6 +523,7 @@
         "invalidVersionString": "Invalid version string found",
         "duplicateNameAndPlatform": "A version with this name and compatible platform already exists",
         "invalidNumOfPlatforms": "Invalid number of platforms",
+        "invalidNumberOfFiles": "Invalid number of files - a version must include at least one jar or external url",
         "duplicate": "A version with this file already exists",
         "noFile": "Could not find uploaded file",
         "mismatchedFileSize": "File sizes do not match",


### PR DESCRIPTION
## Summary

Marks the genuinely-required `VersionUpload` fields as required in the generated OpenAPI schema for `POST /api/v1/projects/{slug}/upload`, and fixes a mislabeled validation message on `files`.

- Added `requiredMode = Schema.RequiredMode.REQUIRED` to the `@Schema` annotations on `version` (`@NotBlank`), `platformDependencies` (`@Size(min = 1)`), and `channel` (`@NotBlank`).
- Added an explicit `@Schema(description = ..., requiredMode = REQUIRED)` to `files`, which previously had no `@Schema` at all and was therefore undocumented despite being mandatory (`@Size(min = 1)`).
- Fixed the `@Size` message on `files`: it reused `version.new.error.invalidNumOfPlatforms` (which renders as "Invalid number of platforms") even though the real problem is that no jar/url was provided. It now points at a new `version.new.error.invalidNumberOfFiles` key added to `frontend/app/i18n/locales/en.json`.
- Left `description` and `pluginDependencies` optional, since they are nullable / have defaults.

`Schema.RequiredMode` is a nested enum on the already-imported `io.swagger.v3.oas.annotations.media.Schema`, so no new import is needed. This mirrors the existing usage in `CreateAPIKeyForm.java`.

## Why this matters

The OpenAPI docs did not mark several `versionUpload` fields as required, so users following the documented "minimum" payload omitted fields that are actually mandatory. The undocumented `files` constraint was the most confusing: omitting it failed validation with a message that talked about platforms rather than files.

See https://github.com/HangarMC/Hangar/issues/1408

## Testing

- Inspect the generated OpenAPI spec / Swagger UI: `versionUpload.version`, `versionUpload.platformDependencies`, `versionUpload.channel`, and `versionUpload.files` now appear as required; `description` and `pluginDependencies` remain optional.
- The new `version.new.error.invalidNumberOfFiles` i18n key resolves to a files-specific message.

This change is annotation- and message-only; it does not alter constructor logic or `toPendingVersion`. The deeper 500 -> 400 behavior when `files` is empty depends on how Spring surfaces the multipart `@RequestPart @Valid` constraint violation and is left as a separate follow-up.

Fixes #1408
